### PR TITLE
Logic for merging releases during promotion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,14 +2,17 @@ module github.com/nestoca/joy-cli
 
 go 1.19
 
-require github.com/spf13/cobra v1.7.0
+require (
+	github.com/fatih/color v1.15.0
+	github.com/kyokomi/emoji v2.2.4+incompatible
+	github.com/spf13/cobra v1.7.0
+	github.com/stretchr/testify v1.8.4
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/fatih/color v1.15.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/kyokomi/emoji v2.2.4+incompatible // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
@@ -19,8 +22,6 @@ require (
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/stretchr/objx v0.5.0 // indirect
-	github.com/stretchr/testify v1.8.4 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
@@ -31,5 +32,5 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.16.0
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,7 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
+github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -99,6 +100,7 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -130,8 +132,10 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kyokomi/emoji v2.2.4+incompatible h1:np0woGKwx9LiHAQmwZx79Oc0rHpNw3o+3evou4BEPv4=
 github.com/kyokomi/emoji v2.2.4+incompatible/go.mod h1:mZ6aGCD7yk8j6QY6KICwnZ2pxoszVseX1DNoGtU2tBA=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -151,6 +155,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
 github.com/spf13/afero v1.9.5/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
@@ -166,7 +171,6 @@ github.com/spf13/viper v1.16.0 h1:rGGH0XDZhdUOryiDWjmIvUSWpbNqisK8Wk0Vyefw8hc=
 github.com/spf13/viper v1.16.0/go.mod h1:yg78JgCJcbrQOvV9YLXgkLaZqUidkY9K+Dd1FofRzQg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -474,6 +478,7 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=

--- a/internal/release/merge/merge.go
+++ b/internal/release/merge/merge.go
@@ -1,0 +1,100 @@
+package merge
+
+import (
+	"gopkg.in/yaml.v3"
+	"regexp"
+)
+
+var lockMarkerRegex = regexp.MustCompile(`(?m)^##\s*lock\s*$`)
+
+// Merge merges the locked subtrees from src onto dest.
+func Merge(dest *yaml.Node, src *yaml.Node) {
+	if dest.Kind != yaml.DocumentNode || src.Kind != yaml.DocumentNode {
+		return
+	}
+
+	result := mergeSubTrees(dest.Content[0], src.Content[0])
+	if result != nil {
+		dest.Content[0] = result
+	}
+}
+
+func mergeSubTrees(dest, src *yaml.Node) *yaml.Node {
+	lockMarkerFound := false
+
+	if dest == nil {
+		dest = &yaml.Node{
+			Kind:        yaml.MappingNode,
+			Content:     []*yaml.Node{},
+			HeadComment: src.HeadComment,
+			LineComment: src.LineComment,
+			FootComment: src.FootComment,
+		}
+	}
+
+	if dest.Kind != yaml.MappingNode || src.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	for i := 0; i < len(src.Content)-1; i += 2 {
+		// Read key and value
+		keyNode := src.Content[i]
+		valueNode := src.Content[i+1]
+		if keyNode.Kind != yaml.ScalarNode {
+			continue
+		}
+		key := keyNode.Value
+
+		// Find destination location
+		destIndex := findKey(dest, key)
+		var destValueNode *yaml.Node
+		if destIndex != -1 {
+			destValueNode = dest.Content[destIndex+1]
+		}
+
+		var subtree *yaml.Node
+		isKeyNodeMarkedAsLocked :=
+			lockMarkerRegex.MatchString(keyNode.HeadComment) ||
+				lockMarkerRegex.MatchString(keyNode.LineComment)
+		isValueNodeMarkedAsLocked :=
+			valueNode.Kind == yaml.ScalarNode && lockMarkerRegex.MatchString(valueNode.LineComment)
+		if isKeyNodeMarkedAsLocked || isValueNodeMarkedAsLocked {
+			lockMarkerFound = true
+			subtree = valueNode
+		} else {
+			subtree = mergeSubTrees(destValueNode, valueNode)
+		}
+
+		// Was a subtree with some locked nodes in it found?
+		if subtree != nil {
+			lockMarkerFound = true
+			// Are we overwriting an existing node?
+			if destIndex != -1 {
+				dest.Content[destIndex] = keyNode
+				dest.Content[destIndex+1] = subtree
+			} else {
+				// We are adding a new node
+				dest.Content = append(dest.Content, keyNode, subtree)
+			}
+		}
+	}
+
+	if lockMarkerFound {
+		dest.Style = src.Style
+		return dest
+	}
+	return nil
+}
+
+func findKey(node *yaml.Node, key string) int {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return -1
+	}
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		keyNode := node.Content[i]
+		if keyNode.Kind == yaml.ScalarNode && keyNode.Value == key {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/release/merge/merge_test.go
+++ b/internal/release/merge/merge_test.go
@@ -219,6 +219,42 @@ func TestMergeWhenBothYAMLsAreEmpty(t *testing.T) {
 	testMergeYAMLFiles(t, aContent, bContent, expectedContent)
 }
 
+func TestMergeSanitizeLockedDestinationScalarsAsTodo(t *testing.T) {
+	aContent := `
+a: b
+c: d
+e:
+  f: g
+  h: i
+  ## lock
+  j:
+    k: l
+`
+	bContent := `
+m: n
+o: p
+e:
+  ## lock
+  f: q
+  r: s
+`
+	expectedContent := `
+a: b
+c: d
+e:
+  ## lock
+  f: q
+  h: i
+  ## lock
+  j:
+    k: TODO
+`
+
+	testMergeYAMLFiles(t, aContent, bContent, expectedContent)
+}
+
+// TODO: Add tests for merging arrays
+
 func testMergeYAMLFiles(t *testing.T, aContent, bContent, expectedContent string) {
 	// Parse a.yaml
 	var aMap yaml.Node

--- a/internal/release/merge/merge_test.go
+++ b/internal/release/merge/merge_test.go
@@ -1,0 +1,258 @@
+package merge
+
+import (
+	"bytes"
+	"gopkg.in/yaml.v3"
+	"strings"
+	"testing"
+)
+
+func TestMergeLockedSubTreesIntoExistingSubTrees(t *testing.T) {
+	aContent := `
+a: b
+c: d
+e:
+  f: g
+  h: i
+  j:
+    k: l
+`
+	bContent := `
+m: n
+o: p
+e:
+  ## lock
+  f: q
+  r: s
+  ## lock
+  j:
+    t: u
+`
+	expectedContent := `
+a: b
+c: d
+e:
+  ## lock
+  f: q
+  h: i
+  ## lock
+  j:
+    t: u
+`
+
+	testMergeYAMLFiles(t, aContent, bContent, expectedContent)
+}
+
+func TestMergeMultipleComments(t *testing.T) {
+	aContent := `
+a: b
+c: d
+e:
+  f: g
+  h: i
+  j:
+    k: l
+`
+	bContent := `
+m: n
+o: p
+e:
+  # Normal comment before lock
+  ## lock
+  f: q
+  r: s
+  ## lock
+  # Normal comment after lock
+  j:
+    t: u
+`
+	expectedContent := `
+a: b
+c: d
+e:
+  # Normal comment before lock
+  ## lock
+  f: q
+  h: i
+  ## lock
+  # Normal comment after lock
+  j:
+    t: u
+`
+
+	testMergeYAMLFiles(t, aContent, bContent, expectedContent)
+}
+
+func TestMergeLineCommentLockMarker(t *testing.T) {
+	aContent := `
+a: b
+c: d
+e:
+  f: g
+  h: i
+  j:
+    k: l
+`
+	bContent := `
+m: n
+o: p
+e:
+  f: q ##  lock
+  r: s
+  j: ##  lock
+    t: u
+`
+	expectedContent := `
+a: b
+c: d
+e:
+  f: q ##  lock
+  h: i
+  j: ##  lock
+    t: u
+`
+
+	testMergeYAMLFiles(t, aContent, bContent, expectedContent)
+}
+
+func TestMergePreservingBraces(t *testing.T) {
+	aContent := `
+a: {b: c}
+`
+	bContent := `
+## lock
+d: e
+`
+	expectedContent := `
+a: {b: c}
+## lock
+d: e
+`
+
+	testMergeYAMLFiles(t, aContent, bContent, expectedContent)
+}
+
+func TestMergeLockedSubTreesIntoNonExistingSubTrees(t *testing.T) {
+	aContent := `
+a: b
+c: d
+`
+	bContent := `
+m: n
+o: p
+e:
+  ## lock
+  f: q
+  r: s
+  ## lock
+  j:
+    t: u
+`
+	expectedContent := `
+a: b
+c: d
+e:
+  ## lock
+  f: q
+  ## lock
+  j:
+    t: u
+`
+
+	testMergeYAMLFiles(t, aContent, bContent, expectedContent)
+}
+
+func TestMergeWhenAYAMLIsEmpty(t *testing.T) {
+	aContent := `{}`
+	bContent := `
+m: n
+o: p
+e:
+  ## lock
+  f: q
+  r: s
+  ## lock
+  j:
+    t: u
+`
+	expectedContent := `
+e:
+  ## lock
+  f: q
+  ## lock
+  j:
+    t: u
+`
+
+	testMergeYAMLFiles(t, aContent, bContent, expectedContent)
+}
+
+func TestMergeWhenBYAMLIsEmpty(t *testing.T) {
+	aContent := `
+a: b
+c: d
+e:
+  f: g
+  h: i
+  j:
+    k: l
+`
+	bContent := `{}`
+	expectedContent := `
+a: b
+c: d
+e:
+  f: g
+  h: i
+  j:
+    k: l
+`
+
+	testMergeYAMLFiles(t, aContent, bContent, expectedContent)
+}
+
+func TestMergeWhenBothYAMLsAreEmpty(t *testing.T) {
+	aContent := `{}`
+	bContent := `{}`
+	expectedContent := `{}`
+
+	testMergeYAMLFiles(t, aContent, bContent, expectedContent)
+}
+
+func testMergeYAMLFiles(t *testing.T, aContent, bContent, expectedContent string) {
+	// Parse a.yaml
+	var aMap yaml.Node
+	if err := yaml.Unmarshal([]byte(aContent), &aMap); err != nil {
+		t.Fatalf("Failed to parse a.yaml: %v", err)
+	}
+	aMap.Style = 0
+
+	// Parse b.yaml
+	var bMap yaml.Node
+	if err := yaml.Unmarshal([]byte(bContent), &bMap); err != nil {
+		t.Fatalf("Failed to parse b.yaml: %v", err)
+	}
+	bMap.Style = 0
+
+	// Merge YAML nodes
+	Merge(&aMap, &bMap)
+
+	// Marshal the result with custom indentation
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+
+	if err := encoder.Encode(&aMap); err != nil {
+		t.Fatalf("Failed to marshal the result: %v", err)
+	}
+
+	// Get the encoded result
+	cBytes := buf.Bytes()
+
+	// Compare the result with the expected result
+	actual := strings.TrimSpace(string(cBytes))
+	expected := strings.TrimSpace(expectedContent)
+	if actual != expected {
+		t.Errorf("Merged YAML files do not match the expected result.\nActual:\n%s\nExpected:\n%s", actual, expected)
+	}
+}

--- a/internal/release/merge/merge_test.go
+++ b/internal/release/merge/merge_test.go
@@ -253,7 +253,45 @@ e:
 	testMergeYAMLFiles(t, aContent, bContent, expectedContent)
 }
 
-// TODO: Add tests for merging arrays
+func TestMergeArrays(t *testing.T) {
+	aContent := `
+a: b
+c: d
+e:
+  f:
+    - f
+    - g
+    - h
+    - i
+    - j
+`
+	bContent := `
+m: n
+o: p
+e:
+  ## lock
+  f:
+    - q
+    - r
+    - s
+    - t
+    - u
+`
+	expectedContent := `
+a: b
+c: d
+e:
+  ## lock
+  f:
+    - q
+    - r
+    - s
+    - t
+    - u
+`
+
+	testMergeYAMLFiles(t, aContent, bContent, expectedContent)
+}
 
 func testMergeYAMLFiles(t *testing.T, aContent, bContent, expectedContent string) {
 	// Parse a.yaml


### PR DESCRIPTION
- Subtrees marked as locked with special comment markers are preserved, everything else gets overwritten.
- Source release nodes marked as locked get their leaf scalar value nodes set to "TODO" to indicate that they should be provided by developers in target environment.
- Merging logic is inverted, with result in source release, and both source/target releases trees get altered by this operation, which greatly simplifies the implementation logic, not having to do tons of deep tree cloning operations.