### PR TITLE
Add jac people integration + selective catalog loading/resolving

### DIFF
--- a/cmd/joy/environment.go
+++ b/cmd/joy/environment.go
@@ -27,7 +27,7 @@ func NewEnvironmentSelectCmd() *cobra.Command {
 
 Only selected environments will be included in releases table columns.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return selection.Select(cfg.FilePath, allFlag)
+			return selection.SelectCurrentEnvironments(cfg.FilePath, allFlag)
 		},
 	}
 	cmd.Flags().BoolVarP(&allFlag, "all", "a", false, "Select all environments")

--- a/cmd/joy/project.go
+++ b/cmd/joy/project.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"github.com/nestoca/joy/internal/jac"
+	"github.com/nestoca/joy/internal/project/list"
+	"github.com/spf13/cobra"
+)
+
+func NewProjectCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "projects",
+		Aliases: []string{"project", "proj"},
+		Short:   "Manage projects",
+		Long:    `Manage projects, such as listing and selecting them.`,
+		GroupID: "core",
+	}
+	cmd.AddCommand(NewProjectListCmd())
+	cmd.AddCommand(NewProjectPeopleCmd())
+	return cmd
+}
+
+func NewProjectPeopleCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "people",
+		Short: "List people owning a project via jac cli",
+		Long: `List people owning a project via jac cli.
+
+Calls 'jac people --group <owner1>,<owner2>...' with the owners of the project.
+
+All extra arguments and flags are passed to jac cli as is.
+
+This command requires the jac cli: https://github.com/nestoca/jac
+`,
+		Args:               cobra.ArbitraryArgs,
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return jac.ListProjectPeople(args)
+		},
+	}
+	return cmd
+}
+
+func NewProjectListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List projects and their owners",
+		Aliases: []string{
+			"ls",
+		},
+		Long: `List projects and their owners.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return list.List()
+		},
+	}
+	return cmd
+}

--- a/cmd/joy/release.go
+++ b/cmd/joy/release.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"github.com/TwiN/go-color"
+	"github.com/nestoca/joy/internal/jac"
 	"github.com/nestoca/joy/internal/release"
 	"github.com/nestoca/joy/internal/release/list"
 	"github.com/nestoca/joy/internal/release/promote"
@@ -21,6 +22,7 @@ func NewReleaseCmd() *cobra.Command {
 	cmd.AddCommand(NewReleaseListCmd())
 	cmd.AddCommand(NewReleasePromoteCmd())
 	cmd.AddCommand(NewReleaseSelectCmd())
+	cmd.AddCommand(NewReleasePeopleCmd())
 	return cmd
 }
 
@@ -106,5 +108,26 @@ Only selected releases will be included in releases table and during promotion.`
 		},
 	}
 	cmd.Flags().BoolVarP(&allFlag, "all", "a", false, "Select all releases")
+	return cmd
+}
+
+func NewReleasePeopleCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "people",
+		Short: "List people owning a release's project via jac cli",
+		Long: `List people owning a release's project via jac cli.
+
+Calls 'jac people --group <owner1>,<owner2>...' with the owners of the release's project.
+
+All extra arguments and flags are passed to jac cli as is.
+
+This command requires the jac cli: https://github.com/nestoca/jac
+`,
+		Args:               cobra.ArbitraryArgs,
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return jac.ListReleasePeople(args)
+		},
+	}
 	return cmd
 }

--- a/cmd/joy/root.go
+++ b/cmd/joy/root.go
@@ -58,5 +58,8 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(NewPushCmd())
 	cmd.AddCommand(NewResetCmd())
 
+	// Other commands
+	cmd.AddCommand(NewSecretCmd())
+
 	return cmd
 }

--- a/cmd/joy/root.go
+++ b/cmd/joy/root.go
@@ -48,6 +48,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddGroup(&cobra.Group{ID: "core", Title: "Core commands"})
 	cmd.AddCommand(NewEnvironmentCmd())
 	cmd.AddCommand(NewReleaseCmd())
+	cmd.AddCommand(NewProjectCmd())
 	cmd.AddCommand(NewBuildCmd())
 
 	// Git-oriented commands

--- a/cmd/joy/secret.go
+++ b/cmd/joy/secret.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"github.com/nestoca/joy/internal/secret"
+	"github.com/spf13/cobra"
+)
+
+func NewSecretCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "sealed-secret",
+		Aliases: []string{"sealed-secrets", "secrets", "secret", "sec"},
+		Short:   "Manage sealed secrets",
+		Long: `Manage sealed secrets, such as sealing (encrypting) secrets and importing public certificate from cluster.
+
+This command requires the sealed-secrets kubeseal cli to be installed: https://github.com/bitnami-labs/sealed-secrets 
+`,
+		GroupID: "core",
+	}
+	cmd.AddCommand(NewSecretImportCmd())
+	cmd.AddCommand(NewSecretSealCmd())
+	return cmd
+}
+
+func NewSecretImportCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "import",
+		Short: "Import sealed secrets public certificate from cluster",
+		Long: `Import sealed secrets public certificate from cluster and store it into given environment CRD.
+
+This command requires kubectl cli to be installed: https://kubernetes.io/docs/tasks/tools/#kubectl`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return secret.ImportCert()
+		},
+	}
+	return cmd
+}
+
+func NewSecretSealCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "seal",
+		Short: "Encrypt secret",
+		Long: `Encrypt secret using public certificate of given environment's sealed secrets controller.
+
+This command requires the sealed-secrets kubeseal cli to be installed: https://github.com/bitnami-labs/sealed-secrets
+The sealed secrets public certificate must also have been imported into the environment using 'joy secret import' command.
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return secret.Seal(cfg.Environments.Source)
+		},
+	}
+	return cmd
+}

--- a/go.mod
+++ b/go.mod
@@ -37,3 +37,5 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+replace github.com/AlecAivazis/survey/v2 => github.com/silphid/survey/v2 v2.3.8

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/AlecAivazis/survey/v2 v2.3.7 h1:6I/u8FvytdGsgonrYsVn2t8t4QiRnh6QSTqkkhIiSjQ=
-github.com/AlecAivazis/survey/v2 v2.3.7/go.mod h1:xUTIdE4KCOIjsBAE1JYsUPoCqYdZ1reCfTwbto0Fduo=
 github.com/MichaelTJones/walk v0.0.0-20161122175330-4748e29d5718 h1:FSsoaa1q4jAaeiAUxf9H0PgFP7eA/UL6c3PdJH+nMN4=
 github.com/MichaelTJones/walk v0.0.0-20161122175330-4748e29d5718/go.mod h1:VVwKsx9Dc8rNG55BWqogoJzGubjKnRoXdUvpGbWqeCc=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
@@ -55,6 +53,8 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/silphid/survey/v2 v2.3.8 h1:q1vtbeyF/2JF3PiV/w9AQGgkFykIuJw9u1jOJHK2sX8=
+github.com/silphid/survey/v2 v2.3.8/go.mod h1:xUTIdE4KCOIjsBAE1JYsUPoCqYdZ1reCfTwbto0Fduo=
 github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/internal/build/promote/promote.go
+++ b/internal/build/promote/promote.go
@@ -15,7 +15,9 @@ type Opts struct {
 
 func Promote(opts Opts) error {
 	loadOpts := catalog.LoadOpts{
-		EnvNames: []string{opts.Environment},
+		LoadEnvs:     true,
+		LoadReleases: true,
+		EnvNames:     []string{opts.Environment},
 	}
 	cat, err := catalog.Load(loadOpts)
 	if err != nil {

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -12,6 +12,9 @@ func TestFreeformEnvsAndReleasesLoading(t *testing.T) {
 	assert.NoError(t, err)
 	loadOpts := LoadOpts{
 		Dir:             catalogDir,
+		LoadEnvs:        true,
+		LoadReleases:    true,
+		LoadProjects:    true,
 		SortEnvsByOrder: true,
 	}
 	cat, err := Load(loadOpts)

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -2,6 +2,7 @@ package environment
 
 import (
 	"fmt"
+	"github.com/AlecAivazis/survey/v2"
 	"github.com/nestoca/joy/internal/yml"
 	"gopkg.in/yaml.v3"
 	"path/filepath"
@@ -27,6 +28,10 @@ type Spec struct {
 	// Owners is the list of identifiers of owners of the environment.
 	// It can be any strings that uniquely identifies the owners, such as email addresses or Jac group identifiers.
 	Owners []string `yaml:"owners,omitempty"`
+
+	// SealedSecretsCert is the public certificate of the Sealed Secrets controller for this environment
+	// that can be used to encrypt secrets targeted to this environment using the `joy secret seal` command.
+	SealedSecretsCert string `yaml:"sealedSecretsCert,omitempty"`
 }
 
 type Environment struct {
@@ -62,4 +67,45 @@ func New(file *yml.File) (*Environment, error) {
 	env.File = file
 	env.Dir = filepath.Dir(file.Path)
 	return &env, nil
+}
+
+func SelectSingle(environments []*Environment, current *Environment, message string) (*Environment, error) {
+	// Create list of environment names
+	var envNames []string
+	for _, env := range environments {
+		envNames = append(envNames, env.Name)
+	}
+
+	// Find index of current environment
+	var selectedIndex int
+	for i, env := range environments {
+		if env == current {
+			selectedIndex = i
+			break
+		}
+	}
+
+	// Prompt user to select environment
+	err := survey.AskOne(&survey.Select{
+		Message: message,
+		Options: envNames,
+		Default: selectedIndex,
+	},
+		&selectedIndex,
+		survey.WithPageSize(10),
+		survey.WithValidator(survey.Required),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("prompting for environment: %w", err)
+	}
+	return environments[selectedIndex], nil
+}
+
+func FindByName(environments []*Environment, name string) *Environment {
+	for _, env := range environments {
+		if env.Name == name {
+			return env
+		}
+	}
+	return nil
 }

--- a/internal/environment/selection/select.go
+++ b/internal/environment/selection/select.go
@@ -8,7 +8,7 @@ import (
 	"github.com/nestoca/joy/internal/git"
 )
 
-func Select(configFilePath string, all bool) error {
+func SelectCurrentEnvironments(configFilePath string, all bool) error {
 	err := git.EnsureCleanAndUpToDateWorkingCopy()
 	if err != nil {
 		return err

--- a/internal/environment/selection/select.go
+++ b/internal/environment/selection/select.go
@@ -33,6 +33,7 @@ func Select(configFilePath string, all bool) error {
 
 	// Load catalog
 	loadOpts := catalog.LoadOpts{
+		LoadEnvs:        true,
 		SortEnvsByOrder: true,
 	}
 	cat, err := catalog.Load(loadOpts)

--- a/internal/jac/jac.go
+++ b/internal/jac/jac.go
@@ -1,0 +1,166 @@
+package jac
+
+import (
+	"errors"
+	"fmt"
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/TwiN/go-color"
+	"github.com/nestoca/joy/internal/catalog"
+	"github.com/nestoca/joy/internal/git"
+	"github.com/nestoca/joy/internal/project"
+	"github.com/nestoca/joy/internal/release"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func ListProjectPeople(extraArgs []string) error {
+	err := ensureJacCliInstalled()
+	if err != nil {
+		return err
+	}
+
+	err = git.EnsureCleanAndUpToDateWorkingCopy()
+	if err != nil {
+		return err
+	}
+
+	// Load catalog
+	loadOpts := catalog.LoadOpts{
+		LoadProjects: true,
+	}
+	cat, err := catalog.Load(loadOpts)
+	if err != nil {
+		return fmt.Errorf("loading catalog: %w", err)
+	}
+
+	// Select project
+	selectedProject, err := selectProject(cat.Projects)
+	if err != nil {
+		return err
+	}
+
+	return listPeopleWithGroups(selectedProject.Spec.Owners, extraArgs)
+}
+
+func ListReleasePeople(extraArgs []string) error {
+	err := ensureJacCliInstalled()
+	if err != nil {
+		return err
+	}
+
+	err = git.EnsureCleanAndUpToDateWorkingCopy()
+	if err != nil {
+		return err
+	}
+
+	// Load catalog
+	loadOpts := catalog.LoadOpts{
+		LoadEnvs:     true,
+		LoadReleases: true,
+		LoadProjects: true,
+		ResolveRefs:  true,
+	}
+	cat, err := catalog.Load(loadOpts)
+	if err != nil {
+		return fmt.Errorf("loading catalog: %w", err)
+	}
+
+	// Select cross-release
+	selectedCrossRelease, err := selectCrossRelease(cat.CrossReleases.Items)
+	if err != nil {
+		return err
+	}
+
+	// Find project of first release within cross-release that has a project
+	var proj *project.Project
+	for _, rel := range selectedCrossRelease.Releases {
+		if rel != nil && rel.Project != nil {
+			proj = rel.Project
+			break
+		}
+	}
+	if proj == nil {
+		fmt.Printf("🤷 Release %s has no associated project, please set %s property.\n", color.InYellow(selectedCrossRelease.Name), color.InYellow("spec.project"))
+		return nil
+	}
+
+	// List owners
+	if len(proj.Spec.Owners) == 0 {
+		fmt.Printf("🤷 Project %s has no associated owners, please set %s property.\n", color.InYellow(proj.Name), color.InYellow("spec.owners"))
+		return nil
+	}
+	return listPeopleWithGroups(proj.Spec.Owners, extraArgs)
+}
+
+func listPeopleWithGroups(groups []string, extraArgs []string) error {
+	args := []string{"people", "--group", strings.Join(groups, ",")}
+	args = append(args, extraArgs...)
+	cmd := exec.Command("jac", args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("running jac command: %w", err)
+	}
+	return nil
+}
+
+func ensureJacCliInstalled() error {
+	cmd := exec.Command("which", "jac")
+	err := cmd.Run()
+	if err != nil {
+		fmt.Println("🤓 This command requires the jac cli.\nSee: https://github.com/nestoca/jac")
+		return errors.New("missing jac cli dependency")
+	}
+	return nil
+}
+
+func selectProject(projects []*project.Project) (*project.Project, error) {
+	var selectedIndex int
+	err := survey.AskOne(&survey.Select{
+		Message: "Select project:",
+		Options: projectNames(projects),
+	},
+		&selectedIndex,
+		survey.WithPageSize(10),
+		survey.WithValidator(survey.Required),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("prompting for project: %w", err)
+	}
+	return projects[selectedIndex], nil
+}
+
+func projectNames(projects []*project.Project) []string {
+	var projectNames []string
+	for _, project := range projects {
+		projectNames = append(projectNames, project.Name)
+	}
+	return projectNames
+}
+
+func selectCrossRelease(releases []*release.CrossRelease) (*release.CrossRelease, error) {
+	var selectedIndex int
+	err := survey.AskOne(&survey.Select{
+		Message: "Select release:",
+		Options: releaseNames(releases),
+	},
+		&selectedIndex,
+		survey.WithPageSize(10),
+		survey.WithValidator(survey.Required),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("prompting for release: %w", err)
+	}
+	return releases[selectedIndex], nil
+}
+
+func releaseNames(releases []*release.CrossRelease) []string {
+	var releaseNames []string
+	for _, release := range releases {
+		releaseNames = append(releaseNames, release.Name)
+	}
+	return releaseNames
+}

--- a/internal/project/list/list.go
+++ b/internal/project/list/list.go
@@ -1,0 +1,50 @@
+package list
+
+import (
+	"fmt"
+	"github.com/nestoca/joy/internal/catalog"
+	"github.com/nestoca/joy/internal/git"
+	"github.com/olekukonko/tablewriter"
+	"os"
+	"strings"
+)
+
+func List() error {
+	err := git.EnsureCleanAndUpToDateWorkingCopy()
+	if err != nil {
+		return err
+	}
+
+	// Load catalog
+	loadOpts := catalog.LoadOpts{
+		LoadProjects: true,
+	}
+	cat, err := catalog.Load(loadOpts)
+	if err != nil {
+		return fmt.Errorf("loading catalog: %w", err)
+	}
+
+	// Configure table
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeaderLine(false)
+	table.SetAutoWrapText(true)
+	table.SetBorder(false)
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetCenterSeparator("")
+
+	// Add header
+	headers := []string{"NAME", "OWNERS"}
+	table.SetHeader(headers)
+
+	// Add rows
+	for _, proj := range cat.Projects {
+		owners := strings.Join(proj.Spec.Owners, " ")
+		row := []string{proj.Name, owners}
+		table.Append(row)
+	}
+
+	table.Render()
+	return nil
+}

--- a/internal/release/list/list.go
+++ b/internal/release/list/list.go
@@ -24,6 +24,8 @@ func List(opts Opts) error {
 
 	// Load catalog
 	loadOpts := catalog.LoadOpts{
+		LoadEnvs:        true,
+		LoadReleases:    true,
 		EnvNames:        opts.SelectedEnvs,
 		SortEnvsByOrder: true,
 		ReleaseFilter:   opts.Filter,

--- a/internal/release/promote/promote.go
+++ b/internal/release/promote/promote.go
@@ -29,6 +29,8 @@ func Promote(opts Opts) error {
 
 	// Load catalog
 	loadOpts := catalog.LoadOpts{
+		LoadEnvs:        true,
+		LoadReleases:    true,
 		EnvNames:        []string{opts.SourceEnv, opts.TargetEnv},
 		SortEnvsByOrder: false,
 		ReleaseFilter:   opts.Filter,

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -2,6 +2,8 @@ package release
 
 import (
 	"fmt"
+	"github.com/nestoca/joy/internal/environment"
+	"github.com/nestoca/joy/internal/project"
 	"github.com/nestoca/joy/internal/yml"
 	"gopkg.in/yaml.v3"
 )
@@ -48,6 +50,12 @@ type Release struct {
 	// Missing indicates whether the release is missing in the target environment. During a promotion,
 	// this allows to know whether the release will be created or updated.
 	Missing bool `yaml:"-"`
+
+	// Project is the project that the release belongs to.
+	Project *project.Project `yaml:"-"`
+
+	// Environment is the environment that the release is deployed to.
+	Environment *environment.Environment `yaml:"-"`
 }
 
 func IsValid(apiVersion, kind string) bool {

--- a/internal/release/selection/select.go
+++ b/internal/release/selection/select.go
@@ -33,7 +33,11 @@ func Select(configFilePath string, all bool) error {
 	}
 
 	// Load catalog
-	cat, err := catalog.Load(catalog.LoadOpts{})
+	loadOpts := catalog.LoadOpts{
+		LoadEnvs:     true,
+		LoadReleases: true,
+	}
+	cat, err := catalog.Load(loadOpts)
 	if err != nil {
 		return fmt.Errorf("loading catalog: %w", err)
 	}

--- a/internal/secret/import.go
+++ b/internal/secret/import.go
@@ -1,0 +1,120 @@
+package secret
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/TwiN/go-color"
+	"github.com/nestoca/joy/internal/catalog"
+	"github.com/nestoca/joy/internal/environment"
+	"github.com/nestoca/joy/internal/yml"
+	"os/exec"
+	"strings"
+)
+
+func ImportCert() error {
+	err := ensureKubectlInstalled()
+	if err != nil {
+		return err
+	}
+
+	// Select kube context
+	context, err := selectKubeContext()
+	if err != nil {
+		return fmt.Errorf("selecting kube context: %w", err)
+	}
+
+	// Fetch sealed secret certificate
+	cmd := exec.Command("kubectl",
+		"--context", context,
+		"get", "secret",
+		"-n", "sealed-secrets",
+		"-l", "sealedsecrets.bitnami.com/sealed-secrets-key=active",
+		"-o", "jsonpath={@.items[0].data['tls\\.crt']}")
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("running kubectl command to fetch sealed secret certificate: %w", err)
+	}
+
+	// Decode base64 encoded certificate
+	cert, err := base64.StdEncoding.DecodeString(string(output))
+	if err != nil {
+		return fmt.Errorf("decoding base64 encoded certificate: %w", err)
+	}
+
+	// Load catalog
+	loadOpts := catalog.LoadOpts{
+		LoadEnvs:        true,
+		SortEnvsByOrder: true,
+	}
+	cat, err := catalog.Load(loadOpts)
+	if err != nil {
+		return fmt.Errorf("loading catalog: %w", err)
+	}
+
+	// Select environment
+	selectedEnv, err := environment.SelectSingle(
+		cat.Environments,
+		nil,
+		"Select environment to import sealed secrets certificate into")
+	if err != nil {
+		return fmt.Errorf("selecting environment: %w", err)
+	}
+
+	// Update environment
+	err = yml.SetOrAddNodeValue(selectedEnv.File.Tree, "spec.sealedSecretsCert", string(cert))
+	if err != nil {
+		return fmt.Errorf("updating environment sealed secrets cert node value: %w", err)
+	}
+	err = selectedEnv.File.UpdateYamlFromTree()
+	if err != nil {
+		return fmt.Errorf("updating environment yaml from tree: %w", err)
+	}
+	err = selectedEnv.File.WriteYaml()
+	if err != nil {
+		return fmt.Errorf("writing environment yaml: %w", err)
+	}
+
+	fmt.Printf(`✅ Imported sealed secrets certificate from cluster %s into environment %s
+Make sure to commit and push those changes to git.
+`,
+		color.InYellow(context),
+		color.InYellow(selectedEnv.Name))
+	return nil
+}
+
+func selectKubeContext() (string, error) {
+	// Call `kubectl` to get the list of contexts
+	cmd := exec.Command("kubectl", "config", "get-contexts", "-o", "name")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("running kubectl command to get list of contexts: %w", err)
+	}
+	contexts := strings.Split(strings.TrimSpace(string(output)), "\n")
+
+	// Prompt user to select a context
+	var selectedIndex int
+	err = survey.AskOne(&survey.Select{
+		Message: "Select kube context of cluster to fetch seal secrets certificate from",
+		Options: contexts,
+	},
+		&selectedIndex,
+		survey.WithPageSize(10),
+		survey.WithValidator(survey.Required),
+	)
+	if err != nil {
+		return "", fmt.Errorf("prompting for kube context: %w", err)
+	}
+	return contexts[selectedIndex], nil
+}
+
+func ensureKubectlInstalled() error {
+	cmd := exec.Command("which", "kubectl")
+	err := cmd.Run()
+	if err != nil {
+		fmt.Println("🤓 This command requires kubectl cli to be installed: https://kubernetes.io/docs/tasks/tools/#kubectl")
+		return errors.New("missing kubectl cli dependency")
+	}
+	return nil
+}

--- a/internal/secret/seal.go
+++ b/internal/secret/seal.go
@@ -1,0 +1,113 @@
+package secret
+
+import (
+	"fmt"
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/TwiN/go-color"
+	"github.com/nestoca/joy/internal/catalog"
+	"github.com/nestoca/joy/internal/environment"
+	"github.com/nestoca/joy/internal/utils/colors"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func Seal(env string) error {
+	// Load catalog
+	loadOpts := catalog.LoadOpts{
+		LoadEnvs:        true,
+		SortEnvsByOrder: true,
+	}
+	cat, err := catalog.Load(loadOpts)
+	if err != nil {
+		return fmt.Errorf("loading catalog: %w", err)
+	}
+
+	// Select environment
+	var selectedEnv *environment.Environment
+	if env != "" {
+		selectedEnv = environment.FindByName(cat.Environments, env)
+	}
+	selectedEnv, err = environment.SelectSingle(
+		cat.Environments,
+		selectedEnv,
+		"Select environment to seal secret in")
+	if err != nil {
+		return err
+	}
+
+	// Get sealed secrets certificate
+	cert := selectedEnv.Spec.SealedSecretsCert
+	if cert == "" {
+		fmt.Printf("🤷 Environment %s has no sealed secrets certificate configured, please run `joy secrets import` first.\n", color.InYellow(selectedEnv.Name))
+		return nil
+	}
+
+	// Temporarily tweak multiline question template to start editing on new line and also hide final answer
+	oldTemplate := survey.MultilineQuestionTemplate
+	survey.MultilineQuestionTemplate = `
+{{- if .ShowHelp }}{{- color .Config.Icons.Help.Format }}{{ .Config.Icons.Help.Text }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
+{{- color .Config.Icons.Question.Format }}{{ .Config.Icons.Question.Text }} {{color "reset"}}
+{{- color "default+hb"}}{{ .Message }} {{color "reset"}}
+{{- if .ShowAnswer}}
+{{else}}
+{{- if .Default}}{{color "white"}}({{.Default}}) {{color "reset"}}{{end}}
+{{- color "cyan"}}[Enter 2 empty lines to finish]{{color "reset"}}
+{{end}}`
+	defer func() {
+		survey.MultilineQuestionTemplate = oldTemplate
+	}()
+
+	// Prompt user for multiline secret input
+	var secret string
+	err = survey.AskOne(
+		&survey.Multiline{
+			Message: "Enter secret to seal",
+		},
+		&secret,
+		survey.WithValidator(survey.Required),
+		survey.WithHideCharacter('*'),
+	)
+	if err != nil {
+		return fmt.Errorf("prompting for secret: %w", err)
+	}
+	secret = strings.TrimSpace(secret)
+
+	// Write cert to temporary file
+	certFile, err := writeStringToTempFile(cert)
+	if err != nil {
+		return fmt.Errorf("writing certificate to temporary file: %w", err)
+	}
+	defer os.Remove(certFile)
+
+	// Seal secret by running `kubeseal --raw --scope cluster-wide --cert <cert>`
+	cmd := exec.Command("kubeseal",
+		"--raw",
+		"--scope", "cluster-wide",
+		"--cert", certFile)
+	cmd.Stdin = strings.NewReader(secret)
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("running kubeseal command: %w", err)
+	}
+
+	// Print sealed secret
+	fmt.Println("🔒 Sealed secret:")
+	fmt.Println(colors.InDarkYellow(string(output)))
+	return nil
+}
+
+func writeStringToTempFile(text string) (string, error) {
+	f, err := os.CreateTemp("", "joy-")
+	if err != nil {
+		return "", fmt.Errorf("creating temporary file: %w", err)
+	}
+	defer f.Close()
+
+	_, err = f.WriteString(text)
+	if err != nil {
+		return "", fmt.Errorf("writing to temporary file: %w", err)
+	}
+
+	return f.Name(), nil
+}

--- a/internal/yml/find_node.go
+++ b/internal/yml/find_node.go
@@ -34,6 +34,67 @@ func FindNodeValueOrDefault(node *yaml.Node, path string, defaultValue string) s
 	return resultNode.Value
 }
 
+func SetOrAddNodeValue(node *yaml.Node, path string, value string) error {
+	segments := segmentPath(path)
+
+	// If node is a DocumentNode, we need to retrieve the MappingNode from its Content and traverse it.
+	if node.Kind == yaml.DocumentNode && len(node.Content) == 1 {
+		return setOrAddNodeValue(node.Content[0], segments, value)
+	}
+
+	return setOrAddNodeValue(node, segments, value)
+}
+
+func setOrAddNodeValue(node *yaml.Node, pathSegments []string, value string) error {
+	// Condition is i+1 < len(node.Content) as there always need to be at least 2 entries left in the node.Content for
+	// traversal to work, because each key and its associated value are stored in two consecutive nodes in the slice.
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		keyNode := node.Content[i]
+		valueNode := node.Content[i+1]
+
+		// If the value of the key node matches the first key in the pathSegments, its valueNode contains what we're
+		// looking for (Either the value itself or the next child to search)
+		if keyNode.Value == pathSegments[0] {
+			// If there is only 1 segment left in pathSegments, then this is the droid we are looking for.
+			if len(pathSegments) == 1 {
+				valueNode.Value = value
+				return nil
+			}
+
+			// MappingNodes contain more key/value pairings, so we'll recurse into the next level of the path to search.
+			if valueNode.Kind == yaml.MappingNode {
+				return setOrAddNodeValue(valueNode, pathSegments[1:], value)
+			}
+		}
+	}
+
+	// Add intermediate missing nodes
+	if len(pathSegments) > 1 {
+		for _, segment := range pathSegments[:len(pathSegments)-1] {
+			node.Content = append(node.Content, &yaml.Node{
+				Kind:  yaml.ScalarNode,
+				Value: segment,
+			}, &yaml.Node{
+				Kind: yaml.MappingNode,
+			})
+			node = node.Content[len(node.Content)-1]
+		}
+		// Keep only the last segment
+		pathSegments = pathSegments[len(pathSegments)-1:]
+	}
+
+	// Add terminal missing node
+	node.Content = append(node.Content, &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Value: pathSegments[0],
+	}, &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Value: value,
+	})
+
+	return nil
+}
+
 func findNode(node *yaml.Node, pathSegments []string) (*yaml.Node, error) {
 	// Condition is i+1 < len(node.Content) as there always need to be at least 2 entries left in the node.Content for
 	// traversal to work, because each key and its associated value are stored in two consecutive nodes in the slice.

--- a/internal/yml/find_node_test.go
+++ b/internal/yml/find_node_test.go
@@ -27,10 +27,10 @@ spec:
 func TestFindNodeInDocumentNodeWhenPathExists(t *testing.T) {
 	yamlNode := &yaml.Node{}
 	err := yaml.Unmarshal([]byte(yamlString), yamlNode)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	node, err := FindNode(yamlNode, ".spec.chart.name")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, node)
 
 	assert.Equal(t, "podinfo", node.Value)
@@ -39,13 +39,13 @@ func TestFindNodeInDocumentNodeWhenPathExists(t *testing.T) {
 func TestFindNodeInMappingNodeWhenPathExists(t *testing.T) {
 	yamlNode := &yaml.Node{}
 	err := yaml.Unmarshal([]byte(yamlString), yamlNode)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	mappingNode := yamlNode.Content[0]
 	assert.Equal(t, yaml.MappingNode, mappingNode.Kind)
 
 	node, err := FindNode(mappingNode, ".spec.chart.name")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, node)
 
 	assert.Equal(t, "podinfo", node.Value)
@@ -54,10 +54,10 @@ func TestFindNodeInMappingNodeWhenPathExists(t *testing.T) {
 func TestFindNodeWhenPathDoesNotExist(t *testing.T) {
 	yamlNode := &yaml.Node{}
 	err := yaml.Unmarshal([]byte(yamlString), yamlNode)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	node, err := FindNode(yamlNode, "spec.chart.name.foobar")
-	assert.NotNil(t, err)
+	assert.NoError(t, err)
 	assert.Nil(t, node)
 
 	assert.EqualError(t, err, "node not found for path 'spec.chart.name.foobar': key 'name' does not exist")
@@ -84,10 +84,10 @@ spec:
 
 	yamlNode := &yaml.Node{}
 	err := yaml.Unmarshal([]byte(yamlString), yamlNode)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	node, err := FindNode(yamlNode, ".spec.version")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, node)
 	assert.Equal(t, "1.0.0-avvvvvvd", node.Value)
 
@@ -95,4 +95,34 @@ spec:
 
 	rawBytes, err := yaml.Marshal(yamlNode)
 	assert.Equal(t, expected, string(rawBytes))
+}
+
+func TestSetOrAddNodeValue_AddMissingNodesAndValue(t *testing.T) {
+	yamlNode := &yaml.Node{}
+	err := yaml.Unmarshal([]byte(yamlString), yamlNode)
+	assert.NoError(t, err)
+
+	key := "metadata.annotations.abc.def"
+	value := "test value"
+	err = SetOrAddNodeValue(yamlNode, key, value)
+	assert.NoError(t, err)
+
+	actualValue := FindNodeValueOrDefault(yamlNode, key, "")
+	assert.NoError(t, err)
+	assert.Equal(t, value, actualValue)
+}
+
+func TestSetOrAddNodeValue_SetValueOfExistingNode(t *testing.T) {
+	yamlNode := &yaml.Node{}
+	err := yaml.Unmarshal([]byte(yamlString), yamlNode)
+	assert.NoError(t, err)
+
+	key := "metadata.name"
+	value := "test value"
+	err = SetOrAddNodeValue(yamlNode, key, value)
+	assert.NoError(t, err)
+
+	actualValue := FindNodeValueOrDefault(yamlNode, key, "")
+	assert.NoError(t, err)
+	assert.Equal(t, value, actualValue)
 }


### PR DESCRIPTION
- Add `joy release people` and `joy project people` commands.
- Allow to selectively load aspects (kinds) of catalog and resolve cross-references between entities.