### PR TITLE
fix: Do not run pipeline if only CHANGELOG is updated

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -3,6 +3,8 @@ name: Build, Test and Publish
 on:
   push:
     branches: ["master"]
+    paths-ignore:
+      - "CHANGELOG.md"
   pull_request:
     branches: ["master"]
 


### PR DESCRIPTION
Intentionally using `fix` prefix here to force a version bump on merge