### PR TITLE
fix: preserve order of locked elements

### DIFF
--- a/internal/git/clean_working_copy.go
+++ b/internal/git/clean_working_copy.go
@@ -10,9 +10,9 @@ import (
 
 func EnsureCleanAndUpToDateWorkingCopy() error {
 	cmd := exec.Command("git", "status", "--porcelain")
-	outputBytes, err := cmd.Output()
+	outputBytes, err := cmd.CombinedOutput()
 	if err != nil {
-		return err
+		return fmt.Errorf("checking git status: %s", string(outputBytes))
 	}
 
 	output := strings.TrimSpace(string(outputBytes))

--- a/internal/yml/merge_test.go
+++ b/internal/yml/merge_test.go
@@ -380,3 +380,34 @@ e:
 		t.Errorf("Mismatch (-expected +actual):\n%s", diff)
 	}
 }
+
+func TestMergeLockedElementOnlyPresentInTargetAndNotLastOfHisSiblingsPreservesItsOrder(t *testing.T) {
+	aContent := `
+a: b
+c: d
+e:
+  f: g
+  l: m
+`
+	bContent := `
+a: b
+c: d
+e:
+  f: g
+  h: i
+  ## lock
+  j: k
+  l: m
+`
+	expectedContent := `
+a: b
+c: d
+e:
+  f: g
+  ## lock
+  j: k
+  l: m
+`
+
+	testMergeYAMLFiles(t, aContent, bContent, expectedContent)
+}


### PR DESCRIPTION
Locked elements only present in target yaml were moved to the end of their siblings. We should instead try to preserve their order by looking at keys coming before them and trying to find equivalent insertion position.