### PR TITLE
chore(formatting): add fmt task to makefile: run gofumpt and goimports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,7 @@ test-cov: generate vet
 
 clean:
 	@rm -rf ./reports ./out
+
+fmt:
+	@gofumpt -w .
+	@goimports --local github.com/nestoca/joy,github.com/nestoca -w .

--- a/api/v1alpha1/environment.go
+++ b/api/v1alpha1/environment.go
@@ -2,10 +2,12 @@ package v1alpha1
 
 import (
 	"fmt"
-	"github.com/nestoca/joy/internal/yml"
+	"path/filepath"
+
 	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
-	"path/filepath"
+
+	"github.com/nestoca/joy/internal/yml"
 )
 
 const EnvironmentKind = "Environment"

--- a/api/v1alpha1/release.go
+++ b/api/v1alpha1/release.go
@@ -2,8 +2,10 @@ package v1alpha1
 
 import (
 	"fmt"
-	"github.com/nestoca/joy/internal/yml"
+
 	"gopkg.in/yaml.v3"
+
+	"github.com/nestoca/joy/internal/yml"
 )
 
 const ReleaseKind = "Release"

--- a/cmd/joy/build.go
+++ b/cmd/joy/build.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/nestoca/joy/internal/build"
 	"github.com/spf13/cobra"
+
+	"github.com/nestoca/joy/internal/build"
 )
 
 func NewBuildCmd() *cobra.Command {

--- a/cmd/joy/environment.go
+++ b/cmd/joy/environment.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/nestoca/joy/internal/environment"
 	"github.com/spf13/cobra"
+
+	"github.com/nestoca/joy/internal/environment"
 )
 
 func NewEnvironmentCmd() *cobra.Command {

--- a/cmd/joy/git.go
+++ b/cmd/joy/git.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/nestoca/joy/internal/git"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nestoca/joy/internal/git"
 )
 
 // changeToCatalogDir changes the current directory to the catalog, for commands

--- a/cmd/joy/pr.go
+++ b/cmd/joy/pr.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"fmt"
+
+	"github.com/spf13/cobra"
+
 	"github.com/nestoca/joy/internal/pr/promote"
 	"github.com/nestoca/joy/pkg/catalog"
-	"github.com/spf13/cobra"
 )
 
 func NewPRCmd() *cobra.Command {

--- a/cmd/joy/project.go
+++ b/cmd/joy/project.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/nestoca/joy/internal/jac"
 	"github.com/nestoca/joy/internal/project"
-	"github.com/spf13/cobra"
 )
 
 func NewProjectCmd() *cobra.Command {

--- a/cmd/joy/release.go
+++ b/cmd/joy/release.go
@@ -2,6 +2,11 @@ package main
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+
 	"github.com/nestoca/joy/api/v1alpha1"
 	"github.com/nestoca/joy/internal/jac"
 	"github.com/nestoca/joy/internal/release"
@@ -9,9 +14,6 @@ import (
 	"github.com/nestoca/joy/internal/release/list"
 	"github.com/nestoca/joy/internal/release/promote"
 	"github.com/nestoca/joy/pkg/catalog"
-	"github.com/spf13/cobra"
-	"regexp"
-	"strings"
 )
 
 func NewReleaseCmd() *cobra.Command {

--- a/cmd/joy/root.go
+++ b/cmd/joy/root.go
@@ -2,14 +2,18 @@ package main
 
 import (
 	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
 	"github.com/nestoca/joy/internal/config"
 	"github.com/nestoca/joy/internal/dependencies"
-	"github.com/spf13/cobra"
-	"os"
 )
 
-var cfg *config.Config
-var configDir, catalogDir string
+var (
+	cfg                   *config.Config
+	configDir, catalogDir string
+)
 
 func main() {
 	rootCmd := NewRootCmd()

--- a/cmd/joy/secret.go
+++ b/cmd/joy/secret.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"fmt"
+
+	"github.com/spf13/cobra"
+
 	"github.com/nestoca/joy/internal/secret"
 	"github.com/nestoca/joy/pkg/catalog"
-	"github.com/spf13/cobra"
 )
 
 func NewSecretCmd() *cobra.Command {

--- a/cmd/joy/setup.go
+++ b/cmd/joy/setup.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/nestoca/joy/internal/setup"
 	"github.com/spf13/cobra"
+
+	"github.com/nestoca/joy/internal/setup"
 )
 
 func NewSetupCmd() *cobra.Command {

--- a/internal/build/promote.go
+++ b/internal/build/promote.go
@@ -2,6 +2,7 @@ package build
 
 import (
 	"fmt"
+
 	"github.com/nestoca/joy/internal/style"
 	"github.com/nestoca/joy/internal/yml"
 	"github.com/nestoca/joy/pkg/catalog"

--- a/internal/build/promote_test.go
+++ b/internal/build/promote_test.go
@@ -2,10 +2,11 @@ package build
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const releaseTemplate = `# Some random comment
@@ -184,7 +185,7 @@ func setup(opts setupOpts) (string, error) {
 	// Create environment file
 	environmentFile := filepath.Join(tempDir, "env.yaml")
 	environmentContent := fmt.Sprintf(environmentTemplate, opts.env)
-	err = os.WriteFile(environmentFile, []byte(environmentContent), 0644)
+	err = os.WriteFile(environmentFile, []byte(environmentContent), 0o644)
 	if err != nil {
 		return "", fmt.Errorf("writing environment file: %w", err)
 	}
@@ -194,7 +195,7 @@ func setup(opts setupOpts) (string, error) {
 	if opts.fileContents == "" {
 		opts.fileContents = fmt.Sprintf(releaseTemplate, "promote-build-release", opts.project, "0.0.1")
 	}
-	err = os.WriteFile(releaseFile, []byte(opts.fileContents), 0644)
+	err = os.WriteFile(releaseFile, []byte(opts.fileContents), 0o644)
 	if err != nil {
 		return "", err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,8 +9,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const joyrcFile = ".joyrc"
-const joyDefaultDir = ".joy"
+const (
+	joyrcFile     = ".joyrc"
+	joyDefaultDir = ".joy"
+)
 
 type Config struct {
 	// CatalogDir is the directory containing catalog of environments, projects and releases.
@@ -117,7 +119,7 @@ func (c *Config) Save() error {
 	}
 
 	// Write to file
-	if err := os.WriteFile(c.FilePath, content, 0644); err != nil {
+	if err := os.WriteFile(c.FilePath, content, 0o644); err != nil {
 		return fmt.Errorf("writing config to %s: %w", c.FilePath, err)
 	}
 

--- a/internal/dependencies/dependency.go
+++ b/internal/dependencies/dependency.go
@@ -2,9 +2,10 @@ package dependencies
 
 import (
 	"fmt"
-	"github.com/nestoca/joy/internal/style"
 	"os"
 	"os/exec"
+
+	"github.com/nestoca/joy/internal/style"
 )
 
 type Dependency struct {
@@ -33,8 +34,10 @@ func (d *Dependency) MustBeInstalled() {
 	}
 }
 
-var AllRequired []*Dependency
-var AllOptional []*Dependency
+var (
+	AllRequired []*Dependency
+	AllOptional []*Dependency
+)
 
 func Add(dep *Dependency) {
 	if dep.IsRequired {

--- a/internal/environment/configure_selection.go
+++ b/internal/environment/configure_selection.go
@@ -2,7 +2,9 @@ package environment
 
 import (
 	"fmt"
+
 	"github.com/AlecAivazis/survey/v2"
+
 	"github.com/nestoca/joy/internal/config"
 	"github.com/nestoca/joy/internal/git"
 	"github.com/nestoca/joy/pkg/catalog"

--- a/internal/environment/select_single.go
+++ b/internal/environment/select_single.go
@@ -2,7 +2,9 @@ package environment
 
 import (
 	"fmt"
+
 	"github.com/AlecAivazis/survey/v2"
+
 	"github.com/nestoca/joy/api/v1alpha1"
 )
 

--- a/internal/git/clean_working_copy.go
+++ b/internal/git/clean_working_copy.go
@@ -3,9 +3,10 @@ package git
 import (
 	"bytes"
 	"fmt"
-	"github.com/nestoca/joy/internal/style"
 	"os/exec"
 	"strings"
+
+	"github.com/nestoca/joy/internal/style"
 )
 
 func EnsureCleanAndUpToDateWorkingCopy(dir string) error {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -2,12 +2,14 @@ package git
 
 import (
 	"fmt"
-	"github.com/AlecAivazis/survey/v2"
-	"github.com/nestoca/joy/internal/dependencies"
-	"github.com/nestoca/joy/internal/style"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+
+	"github.com/nestoca/joy/internal/dependencies"
+	"github.com/nestoca/joy/internal/style"
 )
 
 var dependency = &dependencies.Dependency{

--- a/internal/git/pr/github/gh.go
+++ b/internal/git/pr/github/gh.go
@@ -3,12 +3,13 @@ package github
 import (
 	"errors"
 	"fmt"
-	"github.com/nestoca/joy/internal/dependencies"
-	"github.com/nestoca/joy/internal/style"
 	"os"
 	"os/exec"
 	"regexp"
 	"strings"
+
+	"github.com/nestoca/joy/internal/dependencies"
+	"github.com/nestoca/joy/internal/style"
 )
 
 var dependency = &dependencies.Dependency{

--- a/internal/git/pr/github/pull_request_provider.go
+++ b/internal/git/pr/github/pull_request_provider.go
@@ -8,8 +8,7 @@ import (
 	"strings"
 )
 
-type PullRequestProvider struct {
-}
+type PullRequestProvider struct{}
 
 var labelRegex = regexp.MustCompile(`^promote:(.+)$`)
 

--- a/internal/jac/jac.go
+++ b/internal/jac/jac.go
@@ -2,16 +2,18 @@ package jac
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
 	"github.com/AlecAivazis/survey/v2"
+
 	"github.com/nestoca/joy/api/v1alpha1"
 	"github.com/nestoca/joy/internal/dependencies"
 	"github.com/nestoca/joy/internal/git"
 	"github.com/nestoca/joy/internal/release/cross"
 	"github.com/nestoca/joy/internal/style"
 	"github.com/nestoca/joy/pkg/catalog"
-	"os"
-	"os/exec"
-	"strings"
 )
 
 var dependency = &dependencies.Dependency{

--- a/internal/pr/promote/interactive_prompt_provider.go
+++ b/internal/pr/promote/interactive_prompt_provider.go
@@ -2,12 +2,13 @@ package promote
 
 import (
 	"fmt"
+
 	"github.com/AlecAivazis/survey/v2"
+
 	"github.com/nestoca/joy/internal/style"
 )
 
-type InteractivePromptProvider struct {
-}
+type InteractivePromptProvider struct{}
 
 func (s *InteractivePromptProvider) WhetherToCreateMissingPullRequest() (bool, error) {
 	prompt := &survey.Confirm{

--- a/internal/pr/promote/promotable_environments_test.go
+++ b/internal/pr/promote/promotable_environments_test.go
@@ -1,9 +1,11 @@
 package promote
 
 import (
-	"github.com/go-test/deep"
-	"github.com/nestoca/joy/api/v1alpha1"
 	"testing"
+
+	"github.com/go-test/deep"
+
+	"github.com/nestoca/joy/api/v1alpha1"
 )
 
 func newEnvironment(name string, promotable bool) *v1alpha1.Environment {

--- a/internal/pr/promote/promote_test/git_branch_provider_test.go
+++ b/internal/pr/promote/promote_test/git_branch_provider_test.go
@@ -1,10 +1,12 @@
 package promote_test
 
 import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/nestoca/joy/internal/git"
 	"github.com/nestoca/joy/internal/pr/promote"
-	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestGetCurrentBranch(t *testing.T) {

--- a/internal/pr/promote/promote_test/integration_test.go
+++ b/internal/pr/promote/promote_test/integration_test.go
@@ -4,23 +4,27 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/go-test/deep"
-	"github.com/google/uuid"
-	"github.com/nestoca/joy/internal/git"
-	"github.com/nestoca/joy/internal/git/pr/github"
-	"github.com/nestoca/joy/internal/pr/promote"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/mock/gomock"
 	"os"
 	"os/exec"
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/go-test/deep"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/nestoca/joy/internal/git"
+	"github.com/nestoca/joy/internal/git/pr/github"
+	"github.com/nestoca/joy/internal/pr/promote"
 )
 
-var promotableEnvs = []string{"staging", "demo"}
-var commonLabels = []string{"label1", "label2", "label3"}
-var possiblePromotionLabels = []string{"promote:staging", "promote:demo"}
+var (
+	promotableEnvs          = []string{"staging", "demo"}
+	commonLabels            = []string{"label1", "label2", "label3"}
+	possiblePromotionLabels = []string{"promote:staging", "promote:demo"}
+)
 
 func TestPromotePRs(t *testing.T) {
 	testCases := []struct {

--- a/internal/pr/promote/promote_test/main_test.go
+++ b/internal/pr/promote/promote_test/main_test.go
@@ -1,8 +1,9 @@
 package promote_test
 
 import (
-	"github.com/nestoca/joy/internal/testutils"
 	"testing"
+
+	"github.com/nestoca/joy/internal/testutils"
 )
 
 func TestMain(m *testing.M) {

--- a/internal/pr/promote/promote_test/promotion_test.go
+++ b/internal/pr/promote/promote_test/promotion_test.go
@@ -1,12 +1,14 @@
 package promote_test
 
 import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
 	"github.com/nestoca/joy/api/v1alpha1"
 	"github.com/nestoca/joy/internal/git/pr"
 	"github.com/nestoca/joy/internal/pr/promote"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/mock/gomock"
-	"testing"
 )
 
 func newEnvironment(name string, promotable bool) *v1alpha1.Environment {

--- a/internal/pr/promote/promotion.go
+++ b/internal/pr/promote/promotion.go
@@ -2,6 +2,7 @@ package promote
 
 import (
 	"fmt"
+
 	"github.com/nestoca/joy/api/v1alpha1"
 	"github.com/nestoca/joy/internal/git/pr"
 	"github.com/nestoca/joy/internal/git/pr/github"

--- a/internal/project/list.go
+++ b/internal/project/list.go
@@ -2,11 +2,13 @@ package project
 
 import (
 	"fmt"
-	"github.com/nestoca/joy/internal/git"
-	"github.com/nestoca/joy/pkg/catalog"
-	"github.com/olekukonko/tablewriter"
 	"os"
 	"strings"
+
+	"github.com/olekukonko/tablewriter"
+
+	"github.com/nestoca/joy/internal/git"
+	"github.com/nestoca/joy/pkg/catalog"
 )
 
 func List(catalogDir string) error {

--- a/internal/release/configure_selection.go
+++ b/internal/release/configure_selection.go
@@ -2,11 +2,13 @@ package release
 
 import (
 	"fmt"
+	"sort"
+
 	"github.com/AlecAivazis/survey/v2"
+
 	"github.com/nestoca/joy/internal/config"
 	"github.com/nestoca/joy/internal/git"
 	"github.com/nestoca/joy/pkg/catalog"
-	"sort"
 )
 
 func ConfigureSelection(catalogDir, configFilePath string, all bool) error {

--- a/internal/release/cross/release.go
+++ b/internal/release/cross/release.go
@@ -2,10 +2,11 @@ package cross
 
 import (
 	"fmt"
+	"path/filepath"
+
 	"github.com/nestoca/joy/api/v1alpha1"
 	"github.com/nestoca/joy/internal/style"
 	"github.com/nestoca/joy/internal/yml"
-	"path/filepath"
 )
 
 // Release describes a given release across multiple environments

--- a/internal/release/cross/release_list.go
+++ b/internal/release/cross/release_list.go
@@ -2,12 +2,14 @@ package cross
 
 import (
 	"fmt"
+	"sort"
+	"strings"
+
+	"golang.org/x/exp/slices"
+
 	"github.com/nestoca/joy/api/v1alpha1"
 	"github.com/nestoca/joy/internal/release/filtering"
 	"github.com/nestoca/joy/internal/yml"
-	"golang.org/x/exp/slices"
-	"sort"
-	"strings"
 )
 
 // ReleaseList describes multiple releases across multiple environments

--- a/internal/release/filtering/filter.go
+++ b/internal/release/filtering/filter.go
@@ -1,8 +1,9 @@
 package filtering
 
 import (
-	"github.com/nestoca/joy/api/v1alpha1"
 	"strings"
+
+	"github.com/nestoca/joy/api/v1alpha1"
 )
 
 type Filter interface {

--- a/internal/release/list/list.go
+++ b/internal/release/list/list.go
@@ -2,14 +2,16 @@ package list
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
+	"github.com/olekukonko/tablewriter"
+
 	"github.com/nestoca/joy/internal/git"
 	"github.com/nestoca/joy/internal/release/cross"
 	"github.com/nestoca/joy/internal/release/filtering"
 	"github.com/nestoca/joy/internal/style"
 	"github.com/nestoca/joy/pkg/catalog"
-	"github.com/olekukonko/tablewriter"
-	"os"
-	"strings"
 )
 
 type Opts struct {

--- a/internal/release/promote/interactive_prompt_provider.go
+++ b/internal/release/promote/interactive_prompt_provider.go
@@ -3,17 +3,19 @@ package promote
 import (
 	"bytes"
 	"fmt"
+	"strings"
+	"text/tabwriter"
+
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/core"
 	"github.com/hexops/gotextdiff"
 	"github.com/hexops/gotextdiff/myers"
 	"github.com/hexops/gotextdiff/span"
+
 	"github.com/nestoca/joy/api/v1alpha1"
 	"github.com/nestoca/joy/internal/release/cross"
 	"github.com/nestoca/joy/internal/style"
 	"github.com/nestoca/joy/internal/yml"
-	"strings"
-	"text/tabwriter"
 )
 
 type InteractivePromptProvider struct {

--- a/internal/release/promote/perform.go
+++ b/internal/release/promote/perform.go
@@ -2,10 +2,12 @@ package promote
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/google/uuid"
+
 	"github.com/nestoca/joy/api/v1alpha1"
 	"github.com/nestoca/joy/internal/release/cross"
-	"strings"
 )
 
 // perform performs the promotion of all releases in given list and returns PR url if any

--- a/internal/release/promote/promotion.go
+++ b/internal/release/promote/promotion.go
@@ -2,6 +2,7 @@ package promote
 
 import (
 	"fmt"
+
 	"github.com/nestoca/joy/api/v1alpha1"
 	"github.com/nestoca/joy/internal/git/pr"
 	"github.com/nestoca/joy/internal/git/pr/github"

--- a/internal/release/promote/shell_git_provider.go
+++ b/internal/release/promote/shell_git_provider.go
@@ -2,6 +2,7 @@ package promote
 
 import (
 	"fmt"
+
 	"github.com/nestoca/joy/internal/git"
 )
 

--- a/internal/release/promote/test/integration_test.go
+++ b/internal/release/promote/test/integration_test.go
@@ -1,15 +1,17 @@
 package promote_test
 
 import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
 	"github.com/nestoca/joy/api/v1alpha1"
 	"github.com/nestoca/joy/internal/git/pr/github"
 	"github.com/nestoca/joy/internal/release/cross"
 	"github.com/nestoca/joy/internal/release/promote"
 	"github.com/nestoca/joy/pkg/catalog"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/mock/gomock"
-	"os/exec"
-	"testing"
 )
 
 func TestPromoteAllReleasesFromStagingToProd(t *testing.T) {

--- a/internal/release/promote/test/main_test.go
+++ b/internal/release/promote/test/main_test.go
@@ -1,8 +1,9 @@
 package promote_test
 
 import (
-	"github.com/nestoca/joy/internal/testutils"
 	"testing"
+
+	"github.com/nestoca/joy/internal/testutils"
 )
 
 func TestMain(m *testing.M) {

--- a/internal/release/promote/test/promotion_test.go
+++ b/internal/release/promote/test/promotion_test.go
@@ -2,24 +2,28 @@ package promote_test
 
 import (
 	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
 	"github.com/nestoca/joy/api/v1alpha1"
 	"github.com/nestoca/joy/internal/git/pr"
 	"github.com/nestoca/joy/internal/release/cross"
 	"github.com/nestoca/joy/internal/release/promote"
 	"github.com/nestoca/joy/internal/yml"
 	"github.com/nestoca/joy/pkg/catalog"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/mock/gomock"
-	"testing"
 )
 
-const devEnvIndex = 0
-const stagingEnvIndex = 1
-const prodEnvIndex = 2
-const sourceEnvIndex = stagingEnvIndex
-const targetEnvIndex = prodEnvIndex
-const sourceEnvName = "staging"
-const targetEnvName = "prod"
+const (
+	devEnvIndex     = 0
+	stagingEnvIndex = 1
+	prodEnvIndex    = 2
+	sourceEnvIndex  = stagingEnvIndex
+	targetEnvIndex  = prodEnvIndex
+	sourceEnvName   = "staging"
+	targetEnvName   = "prod"
+)
 
 type setupArgs struct {
 	t              *testing.T

--- a/internal/secret/import.go
+++ b/internal/secret/import.go
@@ -3,14 +3,16 @@ package secret
 import (
 	"encoding/base64"
 	"fmt"
+	"os/exec"
+	"strings"
+
 	"github.com/AlecAivazis/survey/v2"
+
 	"github.com/nestoca/joy/internal/dependencies"
 	"github.com/nestoca/joy/internal/environment"
 	"github.com/nestoca/joy/internal/style"
 	"github.com/nestoca/joy/internal/yml"
 	"github.com/nestoca/joy/pkg/catalog"
-	"os/exec"
-	"strings"
 )
 
 var kubectlDependency = &dependencies.Dependency{

--- a/internal/secret/seal.go
+++ b/internal/secret/seal.go
@@ -2,14 +2,16 @@ package secret
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
 	"github.com/AlecAivazis/survey/v2"
+
 	"github.com/nestoca/joy/api/v1alpha1"
 	"github.com/nestoca/joy/internal/environment"
 	"github.com/nestoca/joy/internal/style"
 	"github.com/nestoca/joy/pkg/catalog"
-	"os"
-	"os/exec"
-	"strings"
 )
 
 func Seal(cat *catalog.Catalog, env string) error {

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -2,19 +2,23 @@ package setup
 
 import (
 	"fmt"
-	"github.com/AlecAivazis/survey/v2"
-	"github.com/nestoca/joy/internal/config"
-	"github.com/nestoca/joy/internal/dependencies"
-	"github.com/nestoca/joy/internal/style"
-	"github.com/nestoca/joy/pkg/catalog"
 	"os"
 	"os/exec"
 	"path"
 	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+
+	"github.com/nestoca/joy/internal/config"
+	"github.com/nestoca/joy/internal/dependencies"
+	"github.com/nestoca/joy/internal/style"
+	"github.com/nestoca/joy/pkg/catalog"
 )
 
-const defaultCatalogDir = "~/.joy"
-const separator = "————————————————————————————————————————————————————————————————————————————————"
+const (
+	defaultCatalogDir = "~/.joy"
+	separator         = "————————————————————————————————————————————————————————————————————————————————"
+)
 
 func Setup(configDir, catalogDir, catalogRepo string) error {
 	fmt.Println("👋 Hey there, let's kickstart your most joyful CD experience! ☀️")

--- a/internal/style/style.go
+++ b/internal/style/style.go
@@ -2,8 +2,10 @@ package style
 
 import "github.com/TwiN/go-color"
 
-const darkGrey = "\033[38;2;90;90;90m"
-const darkYellow = "\033[38;2;128;128;0m"
+const (
+	darkGrey   = "\033[38;2;90;90;90m"
+	darkYellow = "\033[38;2;128;128;0m"
+)
 
 // SecondaryInfo is for text that should be less prominent than the main text
 func SecondaryInfo(s any) string {

--- a/internal/yml/encode.go
+++ b/internal/yml/encode.go
@@ -3,8 +3,9 @@ package yml
 import (
 	"bytes"
 	"errors"
-	"gopkg.in/yaml.v3"
 	"reflect"
+
+	"gopkg.in/yaml.v3"
 )
 
 func EncodeYaml(obj any) ([]byte, error) {

--- a/internal/yml/file.go
+++ b/internal/yml/file.go
@@ -3,9 +3,10 @@ package yml
 import (
 	"bytes"
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"os"
 	"path/filepath"
+
+	"gopkg.in/yaml.v3"
 )
 
 // File represents a yaml file loaded into memory in different forms,
@@ -132,7 +133,7 @@ func marshallTreeToYaml(tree *yaml.Node, indent int) ([]byte, error) {
 }
 
 func (y *File) WriteYaml() error {
-	return os.WriteFile(y.Path, y.Yaml, 0644)
+	return os.WriteFile(y.Path, y.Yaml, 0o644)
 }
 
 func (y *File) ToYaml() (string, error) {

--- a/internal/yml/find_node.go
+++ b/internal/yml/find_node.go
@@ -2,14 +2,14 @@ package yml
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 // FindNode traverses a given yaml.Node to locate the value Node of the provided path. The path is interpreted as being
 // relative to the given yaml.Node.
 func FindNode(node *yaml.Node, path string) (resultNode *yaml.Node, err error) {
-
 	var findNodeErr error
 
 	// If node is a DocumentNode, we need to retrieve the MappingNode from its Content and traverse it.

--- a/internal/yml/locking.go
+++ b/internal/yml/locking.go
@@ -9,11 +9,9 @@ import (
 var lockMarkerRegex = regexp.MustCompile(`(?i)(?m)^#+\s*lock\s*$`)
 
 func IsLocked(keyNode, valueNode *yaml.Node) bool {
-	isKeyNodeMarkedAsLocked :=
-		keyNode != nil && (lockMarkerRegex.MatchString(keyNode.HeadComment) ||
-			lockMarkerRegex.MatchString(keyNode.LineComment))
-	isValueNodeMarkedAsLocked :=
-		valueNode != nil &&
-			(valueNode.Kind == yaml.ScalarNode && lockMarkerRegex.MatchString(valueNode.LineComment))
+	isKeyNodeMarkedAsLocked := keyNode != nil && (lockMarkerRegex.MatchString(keyNode.HeadComment) ||
+		lockMarkerRegex.MatchString(keyNode.LineComment))
+	isValueNodeMarkedAsLocked := valueNode != nil &&
+		(valueNode.Kind == yaml.ScalarNode && lockMarkerRegex.MatchString(valueNode.LineComment))
 	return isKeyNodeMarkedAsLocked || isValueNodeMarkedAsLocked
 }

--- a/internal/yml/merge_test.go
+++ b/internal/yml/merge_test.go
@@ -2,10 +2,11 @@ package yml
 
 import (
 	"bytes"
-	"github.com/google/go-cmp/cmp"
-	"gopkg.in/yaml.v3"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v3"
 )
 
 func TestMergeLockedSubTreesIntoExistingSubTrees(t *testing.T) {

--- a/internal/yml/tree.go
+++ b/internal/yml/tree.go
@@ -3,6 +3,7 @@ package yml
 import (
 	"bytes"
 	"fmt"
+
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/yml/yml_test/compare_test.go
+++ b/internal/yml/yml_test/compare_test.go
@@ -1,8 +1,9 @@
 package yml_test
 
 import (
-	"github.com/nestoca/joy/internal/yml"
 	"testing"
+
+	"github.com/nestoca/joy/internal/yml"
 )
 
 func TestCompare(t *testing.T) {

--- a/internal/yml/yml_test/deep_copy_test.go
+++ b/internal/yml/yml_test/deep_copy_test.go
@@ -1,9 +1,11 @@
 package yml_test
 
 import (
-	"github.com/nestoca/joy/internal/yml"
-	"gopkg.in/yaml.v3"
 	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/nestoca/joy/internal/yml"
 )
 
 func TestDeepCopyNode(t *testing.T) {

--- a/internal/yml/yml_test/find_node_test.go
+++ b/internal/yml/yml_test/find_node_test.go
@@ -1,10 +1,12 @@
 package yml_test
 
 import (
-	"github.com/nestoca/joy/internal/yml"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
-	"testing"
+
+	"github.com/nestoca/joy/internal/yml"
 )
 
 const yamlString = `# Some random comment

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -2,15 +2,17 @@ package catalog
 
 import (
 	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"golang.org/x/exp/slices"
+	"gopkg.in/godo.v2/glob"
+
 	"github.com/nestoca/joy/api/v1alpha1"
 	"github.com/nestoca/joy/internal/release/cross"
 	"github.com/nestoca/joy/internal/release/filtering"
 	"github.com/nestoca/joy/internal/yml"
-	"golang.org/x/exp/slices"
-	"gopkg.in/godo.v2/glob"
-	"path/filepath"
-	"sort"
-	"strings"
 )
 
 type Catalog struct {

--- a/pkg/catalog/catalog_test/catalog_test.go
+++ b/pkg/catalog/catalog_test/catalog_test.go
@@ -1,11 +1,13 @@
 package catalog_test
 
 import (
-	"github.com/nestoca/joy/internal/release/cross"
-	"github.com/nestoca/joy/pkg/catalog"
-	"github.com/stretchr/testify/assert"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nestoca/joy/internal/release/cross"
+	"github.com/nestoca/joy/pkg/catalog"
 )
 
 func TestFreeformEnvsAndReleasesLoading(t *testing.T) {


### PR DESCRIPTION
I noticed that the imports were unorganized (thirdparty + nesto + standard-lib) were all intertwined. 
At previous companies we generally leaned on tools such as gofumpt (compliant gofmt formatter but stricter) and goimports to format and organize our imports.

Changes:
- added `fmt` task to makefile
  - run `gofumpt`
  - run `goimports`
- ran fmt task