### PR TITLE
fix: pin build dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,4 +32,4 @@ clean:
 
 fmt:
 	@gofumpt -w .
-	@goimports --local github.com/nestoca/joy,github.com/nestoca -w .
+	@goimports --local github.com/nestoca/joy -w .

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ run:
 	@echo "Ex: 'go run ./cmd/joy help'"
 
 setup:
-	@go install go.uber.org/mock/mockgen@latest
-	@go install mvdan.cc/gofumpt@latest
-	@go install golang.org/x/tools/cmd/goimports@latest
+	@go install go.uber.org/mock/mockgen@v0.3.0
+	@go install mvdan.cc/gofumpt@v0.5.0
+	@go install golang.org/x/tools/cmd/goimports@v0.14.0
 	@go mod download
 
 build: generate


### PR DESCRIPTION
Or else there is no guarantee what will be executed across different environments.

Also uses the same import convention as other projects

As discussed in https://github.com/nestoca/joy/pull/35#discussion_r1377915933

This is a no-op since joy doesn't use our other packages.