### PR TITLE
feat(PL-1917)/introduce lock tag

### DIFF
--- a/cmd/lock-migrator/main.go
+++ b/cmd/lock-migrator/main.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/nestoca/joy/internal/yml"
+	"gopkg.in/yaml.v3"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+var bin = os.Args[0]
+
+func run() error {
+	flag.Usage = func() {
+		fmt.Println(bin)
+		fmt.Println()
+		fmt.Println("description: convert all yaml files within target folder to use tag locks instead of comment locks")
+		fmt.Println()
+		fmt.Printf("usage: %s $TARGET_FOLDER", bin)
+	}
+
+	flag.Parse()
+
+	targetFolder := func() string {
+		if arg := flag.Arg(0); arg != "" {
+			return arg
+		}
+		return "."
+	}()
+
+	return filepath.WalkDir(targetFolder, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			if isHiddenDir(path) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if err := RewriteYAML(path); err != nil {
+			return fmt.Errorf("failed to rewrite %s: %v", path, err)
+		}
+		return nil
+	})
+}
+
+func RewriteYAML(name string) (err error) {
+	data, err := os.ReadFile(name)
+	if err != nil {
+		return err
+	}
+
+	var node Node
+	if err := yaml.Unmarshal(data, &node); err != nil {
+		return err
+	}
+
+	rewriteLocks(node.Node)
+
+	file, err := os.Create(name)
+	if err != nil {
+		return err
+	}
+	defer func() { err = errors.Join(file.Close()) }()
+
+	encoder := yaml.NewEncoder(file)
+	encoder.SetIndent(2)
+
+	return encoder.Encode(node)
+}
+
+func rewriteLocks(node *yaml.Node) {
+	if yml.IsCommentLocked(node) {
+		node.Tag = "!lock"
+		node.LineComment = lockExpression.ReplaceAllString(node.LineComment, "")
+		node.HeadComment = lockExpression.ReplaceAllString(node.LineComment, "")
+	}
+
+	if node.Kind == yaml.MappingNode {
+		for i := 0; i < len(node.Content); i += 2 {
+			key, value := node.Content[i], node.Content[i+1]
+			if yml.IsCommentLocked(key) || yml.IsCommentLocked(value) {
+				value.Tag = "!lock"
+				key.HeadComment = lockExpression.ReplaceAllString(key.HeadComment, "")
+				value.LineComment = lockExpression.ReplaceAllString(value.LineComment, "")
+			}
+		}
+	}
+
+	for _, child := range node.Content {
+		rewriteLocks(child)
+	}
+}
+
+// The node type is a wrapper over a yaml.Node. The reason for this wrapper is to make Marshallinga and Unmarshalling easier.
+// go-yaml fails to unmarshal document nodes, and we always end up needing to go between the document and the first content item.
+// With this we store the first unmashalled node which is the content not the document.
+type Node struct {
+	*yaml.Node
+}
+
+func (n *Node) UnmarshalYAML(node *yaml.Node) error {
+	n.Node = node
+	return nil
+}
+
+func (n Node) MarshalYAML() (any, error) {
+	return n.Node, nil
+}
+
+var lockExpression = regexp.MustCompile(`(?i)(?m)^#+\s*lock\s*\n?`)
+
+func isHiddenDir(name string) bool {
+	return slices.ContainsFunc(filepath.SplitList(name), func(segment string) bool {
+		return segment != "." && strings.HasPrefix(segment, ".")
+	})
+}

--- a/cmd/lock-migrator/main_test.go
+++ b/cmd/lock-migrator/main_test.go
@@ -2,7 +2,7 @@ package main
 
 import "testing"
 
-func TestRegexp(t *testing.T) {
+func TestLockMigratorRegexp(t *testing.T) {
 	cases := []struct {
 		Input  string
 		Output string
@@ -14,6 +14,14 @@ func TestRegexp(t *testing.T) {
 		{
 			Input:  "#lock\n# it!",
 			Output: "# it!",
+		},
+		{
+			Input:  "The quick brown fox jumps over the\n### lock \nlazy dog",
+			Output: "The quick brown fox jumps over the\nlazy dog",
+		},
+		{
+			Input:  "The quick brown fox jumps over the lazy dog\n#lock",
+			Output: "The quick brown fox jumps over the lazy dog\n",
 		},
 	}
 

--- a/cmd/lock-migrator/main_test.go
+++ b/cmd/lock-migrator/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import "testing"
+
+func TestRegexp(t *testing.T) {
+	cases := []struct {
+		Input  string
+		Output string
+	}{
+		{
+			Input:  "#lock",
+			Output: "",
+		},
+		{
+			Input:  "#lock\n# it!",
+			Output: "# it!",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Input, func(t *testing.T) {
+			actual := lockExpression.ReplaceAllString(tc.Input, "")
+			if tc.Output != actual {
+				t.Errorf("expected %q but got %q", tc.Output, actual)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nestoca/joy
 
-go 1.19
+go 1.21
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7

--- a/internal/yml/locking.go
+++ b/internal/yml/locking.go
@@ -8,10 +8,15 @@ import (
 
 var lockMarkerRegex = regexp.MustCompile(`(?i)(?m)^#+\s*lock\s*$`)
 
-func IsLocked(keyNode, valueNode *yaml.Node) bool {
-	isKeyNodeMarkedAsLocked := keyNode != nil && (lockMarkerRegex.MatchString(keyNode.HeadComment) ||
-		lockMarkerRegex.MatchString(keyNode.LineComment))
-	isValueNodeMarkedAsLocked := valueNode != nil &&
-		(valueNode.Kind == yaml.ScalarNode && lockMarkerRegex.MatchString(valueNode.LineComment))
-	return isKeyNodeMarkedAsLocked || isValueNodeMarkedAsLocked
+func IsLocked(key, value *yaml.Node) bool {
+	commentLocked := isCommentLocked(key) || isCommentLocked(value)
+	tagLocked := value != nil && value.Tag == "!lock"
+	return commentLocked || tagLocked
+}
+
+func isCommentLocked(node *yaml.Node) bool {
+	if node == nil {
+		return false
+	}
+	return lockMarkerRegex.MatchString(node.HeadComment) || lockMarkerRegex.MatchString(node.LineComment)
 }

--- a/internal/yml/locking.go
+++ b/internal/yml/locking.go
@@ -9,12 +9,12 @@ import (
 var lockMarkerRegex = regexp.MustCompile(`(?i)(?m)^#+\s*lock\s*$`)
 
 func IsLocked(key, value *yaml.Node) bool {
-	commentLocked := isCommentLocked(key) || isCommentLocked(value)
+	commentLocked := IsCommentLocked(key) || IsCommentLocked(value)
 	tagLocked := value != nil && value.Tag == "!lock"
 	return commentLocked || tagLocked
 }
 
-func isCommentLocked(node *yaml.Node) bool {
+func IsCommentLocked(node *yaml.Node) bool {
 	if node == nil {
 		return false
 	}

--- a/internal/yml/merge_test.go
+++ b/internal/yml/merge_test.go
@@ -9,8 +9,17 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func TestMergeLockedSubTreesIntoExistingSubTrees(t *testing.T) {
-	aContent := `
+type mergeTest struct {
+	Name     string
+	A        string
+	B        string
+	Expected string
+}
+
+var mergeTests = []mergeTest{
+	{
+		Name: "MergeLockedSubTreesIntoExistingSubTrees",
+		A: `
 a: b
 c: d
 e:
@@ -18,8 +27,8 @@ e:
   h: i
   j:
     k: l
-`
-	bContent := `
+`,
+		B: `
 m: n
 o: p
 e:
@@ -29,8 +38,8 @@ e:
   ## lock
   j:
     t: u
-`
-	expectedContent := `
+`,
+		Expected: `
 a: b
 c: d
 e:
@@ -40,13 +49,11 @@ e:
   ## lock
   j:
     t: u
-`
-
-	testMerge(t, &aContent, &bContent, expectedContent)
-}
-
-func TestMergeMultipleComments(t *testing.T) {
-	aContent := `
+`,
+	},
+	{
+		Name: "MergeMultipleComments",
+		A: `
 a: b
 c: d
 e:
@@ -54,8 +61,8 @@ e:
   h: i
   j:
     k: l
-`
-	bContent := `
+`,
+		B: `
 m: n
 o: p
 e:
@@ -67,8 +74,8 @@ e:
   # Normal comment after lock
   j:
     t: u
-`
-	expectedContent := `
+`,
+		Expected: `
 a: b
 c: d
 e:
@@ -80,13 +87,11 @@ e:
   # Normal comment after lock
   j:
     t: u
-`
-
-	testMerge(t, &aContent, &bContent, expectedContent)
-}
-
-func TestMergeLineCommentLockMarker(t *testing.T) {
-	aContent := `
+`,
+	},
+	{
+		Name: "MergeLineCommentLockMarker",
+		A: `
 a: b
 c: d
 e:
@@ -94,8 +99,8 @@ e:
   h: i
   j:
     k: l
-`
-	bContent := `
+`,
+		B: `
 m: n
 o: p
 e:
@@ -103,8 +108,8 @@ e:
   r: s
   j: ##  lock
     t: u
-`
-	expectedContent := `
+`,
+		Expected: `
 a: b
 c: d
 e:
@@ -112,35 +117,31 @@ e:
   h: i
   j: ##  lock
     t: u
-`
-
-	testMerge(t, &aContent, &bContent, expectedContent)
-}
-
-func TestMergePreservingBraces(t *testing.T) {
-	aContent := `
+`,
+	},
+	{
+		Name: "MergePreservingBraces",
+		A: `
 a: {b: c}
-`
-	bContent := `
+`,
+		B: `
 a: b
 ## lock
 d: e
-`
-	expectedContent := `
+`,
+		Expected: `
 a: {b: c}
 ## lock
 d: e
-`
-
-	testMerge(t, &aContent, &bContent, expectedContent)
-}
-
-func TestMergeLockedSubTreesIntoNonExistingSubTrees(t *testing.T) {
-	aContent := `
+`,
+	},
+	{
+		Name: "MergeLockedSubTreesIntoNonExistingSubTrees",
+		A: `
 a: b
 c: d
-`
-	bContent := `
+`,
+		B: `
 m: n
 o: p
 e:
@@ -150,8 +151,8 @@ e:
   ## lock
   j:
     t: u
-`
-	expectedContent := `
+`,
+		Expected: `
 a: b
 c: d
 e:
@@ -160,14 +161,12 @@ e:
   ## lock
   j:
     t: u
-`
-
-	testMerge(t, &aContent, &bContent, expectedContent)
-}
-
-func TestMergeWhenAYAMLIsEmpty(t *testing.T) {
-	aContent := `{}`
-	bContent := `
+`,
+	},
+	{
+		Name: "MergeWhenAYAMLIsEmpty",
+		A:    `{}`,
+		B: `
 m: n
 o: p
 e:
@@ -177,21 +176,19 @@ e:
   ## lock
   j:
     t: u
-`
-	expectedContent := `
+`,
+		Expected: `
 e:
   ## lock
   f: q
   ## lock
   j:
     t: u
-`
-
-	testMerge(t, &aContent, &bContent, expectedContent)
-}
-
-func TestMergeWhenBYAMLIsEmpty(t *testing.T) {
-	aContent := `
+`,
+	},
+	{
+		Name: "MergeWhenBYAMLIsEmpty",
+		A: `
 a: b
 c: d
 e:
@@ -199,9 +196,9 @@ e:
   h: i
   j:
     k: l
-`
-	bContent := `{}`
-	expectedContent := `
+`,
+		B: `{}`,
+		Expected: `
 a: b
 c: d
 e:
@@ -209,27 +206,21 @@ e:
   h: i
   j:
     k: l
-`
-
-	testMerge(t, &aContent, &bContent, expectedContent)
-}
-
-func TestMergeWhenBothYAMLsAreEmpty(t *testing.T) {
-	aContent := `{}`
-	bContent := `{}`
-	expectedContent := `{}`
-
-	testMerge(t, &aContent, &bContent, expectedContent)
-}
-
-func TestMergeWhenBothYAMLsAreNil(t *testing.T) {
-	expectedContent := `{}`
-
-	testMerge(t, nil, nil, expectedContent)
-}
-
-func TestMergeSanitizeLockedDestinationScalarsAsTodo(t *testing.T) {
-	aContent := `
+`,
+	},
+	{
+		Name:     "MergeWhenBothYAMLsAreEmpty",
+		A:        `{}`,
+		B:        `{}`,
+		Expected: `{}`,
+	},
+	{
+		Name:     "MergeWhenBothYAMLsAreNil",
+		Expected: `{}`,
+	},
+	{
+		Name: "MergeSanitizeLockedDestinationScalarsAsTodo",
+		A: `
 a: b
 c: d
 e:
@@ -238,16 +229,16 @@ e:
   ## lock
   j:
     k: l
-`
-	bContent := `
+`,
+		B: `
 m: n
 o: p
 e:
   ## lock
   f: q
   r: s
-`
-	expectedContent := `
+`,
+		Expected: `
 a: b
 c: d
 e:
@@ -257,13 +248,11 @@ e:
   ## lock
   j:
     k: TODO
-`
-
-	testMerge(t, &aContent, &bContent, expectedContent)
-}
-
-func TestMergeSanitizeLockedDestinationScalarsAsTodoWhenTargetIsNil(t *testing.T) {
-	aContent := `
+`,
+	},
+	{
+		Name: "MergeSanitizeLockedDestinationScalarsAsTodoWhenTargetIsNil",
+		A: `
 a: b
 c: d
 e:
@@ -272,9 +261,8 @@ e:
   ## lock
   j:
     k: l
-`
-
-	expectedContent := `
+`,
+		Expected: `
 a: b
 c: d
 e:
@@ -283,13 +271,11 @@ e:
   ## lock
   j:
     k: TODO
-`
-
-	testMerge(t, &aContent, nil, expectedContent)
-}
-
-func TestMergeArrays(t *testing.T) {
-	aContent := `
+`,
+	},
+	{
+		Name: "MergeArrays",
+		A: `
 a: b
 c: d
 e:
@@ -299,8 +285,8 @@ e:
     - h
     - i
     - j
-`
-	bContent := `
+`,
+		B: `
 m: n
 o: p
 e:
@@ -311,8 +297,8 @@ e:
     - s
     - t
     - u
-`
-	expectedContent := `
+`,
+		Expected: `
 a: b
 c: d
 e:
@@ -323,52 +309,160 @@ e:
     - s
     - t
     - u
-`
-
-	testMerge(t, &aContent, &bContent, expectedContent)
+`,
+	},
+	{
+		Name: "MergingLockedElementOnlyPresentInTargetAndNotLastOfHisSiblings_ShouldPreserveItsOrder",
+		A: `
+a: b
+c: d
+e:
+  f: g
+  l: m
+`,
+		B: `
+a: b
+c: d
+e:
+  f: g
+  h: i
+  ## lock
+  j: k
+  l: m
+`,
+		Expected: `
+a: b
+c: d
+e:
+  f: g
+  ## lock
+  j: k
+  l: m
+`,
+	},
+	{
+		Name: "MergingLockedElementWithinParentOnlyPresentInTargetAndFirstOfHisSiblings_ShouldPreserveItsOrder",
+		A: `
+a: b
+c:
+  d: e
+  i: j
+`,
+		B: `
+a: b
+c:
+  f: 
+    ## lock
+    g: h
+  d: e
+`,
+		Expected: `
+a: b
+c:
+  f:
+    ## lock
+    g: h
+  d: e
+  i: j
+`,
+	},
+	{
+		Name: "MergingLockedElementWithinParentOnlyPresentInTargetAndNotLastOfHisSiblings_ShouldPreserveItsOrder",
+		A: `
+a: b
+c:
+  d: e
+  i: j
+`,
+		B: `
+a: b
+c:
+  d: e
+  f: 
+    ## lock
+    g: h
+  k: l
+`,
+		Expected: `
+a: b
+c:
+  d: e
+  f:
+    ## lock
+    g: h
+  i: j
+`,
+	},
+	{
+		Name: "MergingLockedElementToExistingUnlockedTargetElement_ShouldLockTargetElementAndLeaveItsValueUnchanged",
+		A: `
+a: b
+c:
+  ## lock
+  d: e
+  i: j
+`,
+		B: `
+a: b
+c:
+  d: f
+  i: j
+`,
+		Expected: `
+a: b
+c:
+  ## lock
+  d: f
+  i: j
+`,
+	},
 }
 
-func testMerge(t *testing.T, aContent *string, bContent *string, expectedContent string) {
-	// Parse a.yaml
-	var aMap *yaml.Node
-	if aContent != nil {
-		aMap = &yaml.Node{}
-		if err := yaml.Unmarshal([]byte(*aContent), aMap); err != nil {
-			t.Fatalf("Failed to parse a.yaml: %v", err)
-		}
-		aMap.Style = 0
-	}
+func TestMergeTableDriven(t *testing.T) {
+	for _, test := range mergeTests {
+		t.Run(test.Name, func(t *testing.T) {
+			// Parse a.yaml
+			var aMap *yaml.Node
+			if test.A != "" {
+				aMap = &yaml.Node{}
+				if err := yaml.Unmarshal([]byte(test.A), aMap); err != nil {
+					t.Fatalf("Failed to parse a.yaml: %v", err)
+				}
+				aMap.Style = 0
+			}
 
-	// Parse b.yaml
-	var bMap *yaml.Node
-	if bContent != nil {
-		bMap = &yaml.Node{}
-		if err := yaml.Unmarshal([]byte(*bContent), bMap); err != nil {
-			t.Fatalf("Failed to parse b.yaml: %v", err)
-		}
-		bMap.Style = 0
-	}
+			// Parse b.yaml
+			var bMap *yaml.Node
+			if test.B != "" {
+				bMap = &yaml.Node{}
+				if err := yaml.Unmarshal([]byte(test.B), bMap); err != nil {
+					t.Fatalf("Failed to parse b.yaml: %v", err)
+				}
+				bMap.Style = 0
+			}
 
-	// Merge
-	result := Merge(aMap, bMap)
+			// Merge
+			result := Merge(aMap, bMap)
 
-	// Marshal the result with custom indentation
-	var buf bytes.Buffer
-	encoder := yaml.NewEncoder(&buf)
-	encoder.SetIndent(2)
+			// Marshal the result with custom indentation
+			var buf bytes.Buffer
+			encoder := yaml.NewEncoder(&buf)
+			encoder.SetIndent(2)
 
-	if err := encoder.Encode(result); err != nil {
-		t.Fatalf("Failed to marshal the result: %v", err)
-	}
+			if err := encoder.Encode(result); err != nil {
+				t.Fatalf("Failed to marshal the result: %v", err)
+			}
 
-	// Get the encoded result
-	cBytes := buf.Bytes()
+			// Get the encoded result
+			cBytes := buf.Bytes()
 
-	// Compare the result with the expected result
-	actual := strings.TrimSpace(string(cBytes))
-	expected := strings.TrimSpace(expectedContent)
-	if actual != expected {
-		t.Errorf("Merged YAML files do not match the expected result.\nActual:\n%s\nExpected:\n%s", actual, expected)
+			// Compare the result with the expected result
+			actual := strings.TrimSpace(string(cBytes))
+			expected := strings.TrimSpace(test.Expected)
+			if actual != expected {
+				t.Errorf("Merged YAML files do not match the expected result.\nActual:\n%s\nExpected:\n%s", actual, expected)
+			}
+		})
 	}
 }
 
@@ -417,119 +511,6 @@ e:
 	actual := strings.TrimSpace(string(mergedBytes))
 	expected = strings.TrimSpace(expected)
 	if diff := cmp.Diff(expected, actual); diff != "" {
-		t.Errorf("Mismatch (-expected +actual):\n%s", diff)
+		t.Errorf("Mismatch (-expected +actual):%s", diff)
 	}
-}
-
-func Test_MergingLockedElementOnlyPresentInTargetAndNotLastOfHisSiblings_ShouldPreserveItsOrder(t *testing.T) {
-	aContent := `
-a: b
-c: d
-e:
-  f: g
-  l: m
-`
-	bContent := `
-a: b
-c: d
-e:
-  f: g
-  h: i
-  ## lock
-  j: k
-  l: m
-`
-	expectedContent := `
-a: b
-c: d
-e:
-  f: g
-  ## lock
-  j: k
-  l: m
-`
-
-	testMerge(t, &aContent, &bContent, expectedContent)
-}
-
-func Test_MergingLockedElementWithinParentOnlyPresentInTargetAndFirstOfHisSiblings_ShouldPreserveItsOrder(t *testing.T) {
-	aContent := `
-a: b
-c:
-  d: e
-  i: j
-`
-	bContent := `
-a: b
-c:
-  f: 
-    ## lock
-    g: h
-  d: e
-`
-	expectedContent := `
-a: b
-c:
-  f:
-    ## lock
-    g: h
-  d: e
-  i: j
-`
-
-	testMerge(t, &aContent, &bContent, expectedContent)
-}
-
-func Test_MergingLockedElementWithinParentOnlyPresentInTargetAndNotLastOfHisSiblings_ShouldPreserveItsOrder(t *testing.T) {
-	aContent := `
-a: b
-c:
-  d: e
-  i: j
-`
-	bContent := `
-a: b
-c:
-  d: e
-  f: 
-    ## lock
-    g: h
-  k: l
-`
-	expectedContent := `
-a: b
-c:
-  d: e
-  f:
-    ## lock
-    g: h
-  i: j
-`
-
-	testMerge(t, &aContent, &bContent, expectedContent)
-}
-
-func Test_MergingLockedElementToExistingUnlockedTargetElement_ShouldLockTargetElementAndLeaveItsValueUnchanged(t *testing.T) {
-	aContent := `
-a: b
-c:
-  ## lock
-  d: e
-  i: j
-`
-	bContent := `
-a: b
-c:
-  d: f
-  i: j
-`
-	expectedContent := `
-a: b
-c:
-  ## lock
-  d: f
-  i: j
-`
-
-	testMerge(t, &aContent, &bContent, expectedContent)
 }


### PR DESCRIPTION
- feat: IsLocked considers !lock tag
- refactor: merge_test as table driven tests
- feat: added lock based yaml testing


The Lock-Migrator doesn't have any full-blown test suite as it is meant to be a one-off command as we migrate the catalog to use `!lock` tags. The catalog will need to have a PR opened and reviewed which invalidates the effort of creating a test suite for this temporary command.

