### PR TITLE
fix(PL-2090): validate yaml tags in release files

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -102,6 +102,14 @@ func Load(opts LoadOpts) (*Catalog, error) {
 	// Load cross-releases
 	if opts.LoadReleases {
 		allReleaseFiles := c.GetFilesByKind(v1alpha1.ReleaseKind)
+		if err := validateTagsForFiles(allReleaseFiles); err != nil {
+			return nil, fmt.Errorf("release files with invalid tags: %w", err)
+		}
+
+		for _, file := range allReleaseFiles {
+			validateTags(file.Tree)
+		}
+
 		c.Releases, err = cross.LoadReleaseList(allReleaseFiles, c.Environments, opts.ReleaseFilter)
 		if err != nil {
 			return nil, fmt.Errorf("loading cross-environment releases: %w", err)

--- a/pkg/catalog/catalog_test/catalog_test.go
+++ b/pkg/catalog/catalog_test/catalog_test.go
@@ -13,14 +13,14 @@ import (
 func TestFreeformEnvsAndReleasesLoading(t *testing.T) {
 	catalogDir, err := filepath.Abs("testdata/freeform")
 	assert.NoError(t, err)
-	loadOpts := catalog.LoadOpts{
+
+	cat, err := catalog.Load(catalog.LoadOpts{
 		Dir:             catalogDir,
 		LoadEnvs:        true,
 		LoadReleases:    true,
 		LoadProjects:    true,
 		SortEnvsByOrder: true,
-	}
-	cat, err := catalog.Load(loadOpts)
+	})
 	assert.NoError(t, err)
 
 	// Environments

--- a/pkg/catalog/tags.go
+++ b/pkg/catalog/tags.go
@@ -1,0 +1,72 @@
+package catalog
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/nestoca/joy/internal/yml"
+)
+
+func validateTagsForFiles(files []*yml.File) error {
+	var errs []error
+	for _, file := range files {
+		if err := validateTags(file.Tree); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", file.Path, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func validateTags(node *yaml.Node) error {
+	if tags := buildUnknownTagsList(node); len(tags) > 0 {
+		sort.Strings(tags)
+		return fmt.Errorf("unknown tag(s): %s", strings.Join(tags, ", "))
+	}
+	return nil
+}
+
+func buildUnknownTagsList(node *yaml.Node) []string {
+	var (
+		set  = buildUnknownTagsSet(node, nil)
+		list = make([]string, 0, len(set))
+	)
+	for value := range set {
+		list = append(list, value)
+	}
+	return list
+}
+
+func buildUnknownTagsSet(node *yaml.Node, set map[string]struct{}) map[string]struct{} {
+	if set == nil {
+		set = make(map[string]struct{})
+	}
+
+	if !slices.Contains(knownsTags, node.Tag) {
+		set[node.Tag] = struct{}{}
+	}
+
+	for _, content := range node.Content {
+		set = buildUnknownTagsSet(content, set)
+	}
+
+	return set
+}
+
+var knownsTags = []string{
+	// Standard tags
+	"",
+	"!!int",
+	"!!bool",
+	"!!float",
+	"!!map",
+	"!!str",
+	"!!seq",
+
+	// Custom tags
+	"!lock",
+}

--- a/pkg/catalog/tags_test.go
+++ b/pkg/catalog/tags_test.go
@@ -1,0 +1,74 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/nestoca/joy/internal/yml"
+)
+
+func TestValidateTagsForFiles(t *testing.T) {
+	type File struct {
+		Path    string
+		Content string
+	}
+
+	cases := []struct {
+		Name        string
+		Files       []File
+		ExpectedErr string
+	}{
+		{
+			Name: "no unknown tags",
+			Files: []File{
+				{
+					Path:    "./explicit.yaml",
+					Content: "{hello: !!str world, answer: !!int 42, happy: !!bool true, pi: !!float 3.14, arr: !!seq [], dict: !!map {}}",
+				},
+				{
+					Path:    "./implicit.yaml",
+					Content: "{hello: world, answer: 42, happy: true, pi: 3.14, arr: [], dict: {}}",
+				},
+				{
+					Path:    "./custom.yaml",
+					Content: "{pad: !lock ''}",
+				},
+			},
+		},
+		{
+			Name: "unknown tags",
+			Files: []File{
+				{
+					Path:    "./a.yaml",
+					Content: "{secret: !shhh {}, dont: !look {}}",
+				},
+				{
+					Path:    "./b.yaml",
+					Content: "{hello: !!woah {}}",
+				},
+			},
+			ExpectedErr: "./a.yaml: unknown tag(s): !look, !shhh\n./b.yaml: unknown tag(s): !!woah",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			files := make([]*yml.File, len(tc.Files))
+			for i, file := range tc.Files {
+				var node yaml.Node
+				require.NoError(t, yaml.Unmarshal([]byte(file.Content), &node))
+				files[i] = &yml.File{Path: file.Path, Tree: &node}
+			}
+
+			err := validateTagsForFiles(files)
+			if tc.ExpectedErr != "" {
+				require.EqualError(t, err, tc.ExpectedErr)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds validation for unknown yaml tags when loading the catalog's release files.
This will allow us to detect errors when users try to `!lock` values in their releases.