### PR TITLE
chore(packages): add deb package generation in goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,7 +8,7 @@ builds:
       - linux
       - darwin
     ldflags:
-      - -X "main.version=v{{ .Version }}"
+      - -X "main.version={{ .Version }}"
 archives:
   - format: tar.gz
     wrap_in_directory: false
@@ -32,3 +32,16 @@ brews:
     homepage: "https://github.com/nestoca/joy"
     description: "A CLI for happily managing and deploying applications"
     license: "MIT"
+nfpms:
+  - package_name: joy
+    file_name_template: "{{ .ConventionalFileName }}"
+    vendor: nestoca
+    homepage: https://github.com/nestoca/joy
+    description: |-
+      A CLI for happily managing and deploying applications
+    license: MIT
+    maintainer: Mathieu Frenette <mathieu.frenette@nesto.ca>
+    formats:
+      - deb
+    dependencies:
+      - git


### PR DESCRIPTION
Went ahead and added debian package generation in goreleaser via [nfpm](https://goreleaser.com/customization/nfpm/).
@silphid I wasn't sure about which email I should put in the maintainer field, or we could opt to omit this property altogether.

Output of a local goreleaser run:
![image](https://github.com/nestoca/joy/assets/3674538/85fcaba2-ca9c-4ca9-8e31-49665ad87def)

Locally installing the resulting deb package
![image](https://github.com/nestoca/joy/assets/3674538/55770f8f-123d-4b40-bf41-e3f42865ac17)

Validating proper installation
![image](https://github.com/nestoca/joy/assets/3674538/800a5d10-8d9f-4bd3-b04c-32869805f222)
