### PR TITLE
fix(README.md): config file location and name

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Download from GitHub [releases](https://github.com/nestoca/joy/releases/latest) 
 $ git clone git@github.com:<OWNER>/<CATALOG>.git ~/.joy
 ```
 
-That is the default location where joy will look for your catalog repo. If you want to clone your catalog in a different location for convenience, create a `~/.joy/config.yaml` file with the following content to redirect joy to it:
+That is the default location where joy will look for your catalog repo. If you want to clone your catalog in a different location for convenience, create a `~/.joyrc` file with the following content to redirect joy to it:
 
 ```yaml
 catalog-dir: /absolute/path/to/your/catalog


### PR DESCRIPTION
Joy will not read in a configuration file at `~/.joy/config.yaml`.

It looks like the desired workflow is either for the user to create a `~.joyrc` file with the location of the catalog or to run `joy setup` and have the CLI generate a `~.joyrc` file for them if the catalog isn't in the default location.

Also, if joy is unable to find a joy catalog and the user hasn't created a `.joyrc` file, running `joy help` will result in the following message: 
```
Error: no joy catalog found at "/Users/{USERNAME}/.joy"
```

I think that this message should either be changed to one that points the user towards running `joy setup` or doesn't show up at all and lets joy just print the help for the base command. 

Please note that running just `joy` works as expected, and prints the help for the base command without a catalog/configuration. It is the way that I discovered `joy setup`.