### PR TITLE
fix(help): run help without invoking pre run checks

### DIFF
--- a/cmd/joy/root.go
+++ b/cmd/joy/root.go
@@ -25,6 +25,10 @@ func NewRootCmd(version string) *cobra.Command {
 		Short:        "Manages project, environment and release resources as code",
 		SilenceUsage: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.CalledAs() == "help" {
+				return nil
+			}
+
 			if cmd != setupCmd {
 				if err := dependencies.AllRequiredMustBeInstalled(); err != nil {
 					return err


### PR DESCRIPTION
This check makes it so that `joy help` will run without a catalog configured. 

Without something like this, the `config.CheckCatalogDir(cfg.CatalogDir)` function on at the end of the `PersistentPreRunE` will run when on `joy help`, and an error will be printed to the console instead of the help.