### PR TITLE
proposal: fix sequence merging

### DIFF
--- a/internal/yml/promote/merge.go
+++ b/internal/yml/promote/merge.go
@@ -1,0 +1,161 @@
+package promote
+
+import (
+	"slices"
+
+	"gopkg.in/yaml.v3"
+)
+
+func Merge(dst, src *yaml.Node) *yaml.Node {
+	dst = clone(dst)
+
+	doc := func() *yaml.Node {
+		if dst.Kind == yaml.DocumentNode {
+			return dst
+		}
+		return &yaml.Node{Kind: yaml.DocumentNode}
+	}()
+
+	dst = unwrapDocument(dst)
+	src = markLockedValuesAsTodo(clone(unwrapDocument(src)), false)
+
+	doc.Content = []*yaml.Node{merge(dst, src)}
+	return doc
+}
+
+func merge(dst, src *yaml.Node) *yaml.Node {
+	if isLocked(dst) {
+		return dst
+	}
+
+	if dst == nil || src == nil || dst.Kind != src.Kind {
+		return src
+	}
+
+	switch src.Kind {
+	case yaml.MappingNode:
+		return mergeMap(dst, src)
+	case yaml.SequenceNode:
+		return mergeSeq(dst, src)
+	case yaml.ScalarNode:
+		if isLocked(src) {
+			return dst
+		}
+		return src
+	}
+
+	return src
+}
+
+func mergeMap(dst, src *yaml.Node) *yaml.Node {
+	var (
+		dstMap  = asMap(dst)
+		srcMap  = asMap(src)
+		keys    = dedup(append(keysOf(src), keysOf(dst)...))
+		content = make([]*yaml.Node, 0, len(src.Content)+len(dst.Content))
+	)
+
+	for _, key := range keys {
+		if value := merge(dstMap[key], srcMap[key]); value != nil {
+			content = append(content, strNode(key), value)
+		}
+	}
+
+	src.Content = content
+	return src
+}
+
+func mergeSeq(dst, src *yaml.Node) *yaml.Node {
+	maxLen := max(len(dst.Content), len(src.Content))
+	content := make([]*yaml.Node, 0, maxLen)
+	for i := 0; i < maxLen; i++ {
+		if value := merge(at(dst, i), at(src, i)); value != nil {
+			content = append(content, value)
+		}
+	}
+	src.Content = content
+	return src
+}
+
+func unwrapDocument(node *yaml.Node) *yaml.Node {
+	for node != nil && node.Kind == yaml.DocumentNode {
+		if len(node.Content) == 0 {
+			return nil
+		}
+		node = node.Content[0]
+	}
+	return node
+}
+
+func at(node *yaml.Node, i int) *yaml.Node {
+	if i >= len(node.Content) {
+		return nil
+	}
+	return node.Content[i]
+}
+
+func clone(node *yaml.Node) *yaml.Node {
+	copy := *node
+	copy.Content = make([]*yaml.Node, len(node.Content))
+
+	for i, node := range node.Content {
+		copy.Content[i] = clone(node)
+	}
+	return &copy
+}
+
+func markLockedValuesAsTodo(node *yaml.Node, locked bool) *yaml.Node {
+	locked = locked || isLocked(node)
+
+	switch node.Kind {
+	case yaml.ScalarNode:
+		if locked {
+			node.Value = "TODO"
+		}
+	case yaml.SequenceNode, yaml.MappingNode:
+		for i, n := range node.Content {
+			node.Content[i] = markLockedValuesAsTodo(n, locked)
+		}
+	}
+
+	return node
+}
+
+func isLocked(node *yaml.Node) bool {
+	return node != nil && node.Tag == "!lock"
+}
+
+func asMap(node *yaml.Node) map[string]*yaml.Node {
+	result := make(map[string]*yaml.Node, len(node.Content)/2)
+	for i := 0; i < len(node.Content); i += 2 {
+		result[node.Content[i].Value] = node.Content[i+1]
+	}
+	return result
+}
+
+func keysOf(node *yaml.Node) []string {
+	keys := make([]string, 0, len(node.Content)/2)
+	for i := 0; i < len(node.Content); i += 2 {
+		keys = append(keys, node.Content[i].Value)
+	}
+	return keys
+}
+
+func dedup(values []string) []string {
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if slices.Contains(result, value) {
+			continue
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func strNode(value string) *yaml.Node {
+	return &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Tag:   "!!str",
+		Value: value,
+	}
+}

--- a/internal/yml/promote/merge_test.go
+++ b/internal/yml/promote/merge_test.go
@@ -1,0 +1,174 @@
+package promote_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/nestoca/joy/internal/yml"
+	"github.com/nestoca/joy/internal/yml/promote"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestYmlMerge(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Src      string
+		Dst      string
+		Joy      string
+		Proposal string
+	}{
+		{
+			Name:     "conflicting types",
+			Src:      "{key: 1}",
+			Dst:      "{key: hello}",
+			Joy:      "{key: 1}",
+			Proposal: "{key: 1}",
+		},
+		{
+			Name:     "conflicting types locked dst",
+			Src:      "{key: 1}",
+			Dst:      "{key: !lock hello}",
+			Joy:      "{key: !lock hello}",
+			Proposal: "{key: !lock hello}",
+		},
+		{
+			Name:     "conflicting types inner locked dst",
+			Src:      "{key: 1}",
+			Dst:      "{key: [!lock hello]}",
+			Joy:      "{key: 1}",
+			Proposal: "{key: 1}",
+		},
+		{
+			Name:     "conflicting types locked src",
+			Src:      "{key: !lock 1}",
+			Dst:      "{key: hello}",
+			Joy:      "{key: hello}",
+			Proposal: "{key: hello}",
+		},
+		{
+			Name:     "seq",
+			Src:      "[1, 2, 3]",
+			Dst:      "[]",
+			Joy:      "[1, 2, 3]",
+			Proposal: "[1, 2, 3]",
+		},
+		{
+			Name:     "locked seq",
+			Src:      "!lock [1, 2, 3]",
+			Dst:      "[]",
+			Joy:      "!lock [1, 2, 3]",
+			Proposal: "!lock [!!int TODO, !!int TODO, !!int TODO]",
+		},
+		{
+			Name:     "seq with dst longer",
+			Src:      "[1, 2, 3]",
+			Dst:      "[4, 5, 6, 7, 8]",
+			Joy:      "[1, 2, 3]",
+			Proposal: "[1, 2, 3]",
+		},
+		{
+			Name:     "seq with dst longer and lock",
+			Src:      "[1, 2, 3]",
+			Dst:      "[4, 5, 6, 7, !lock 8]",
+			Joy:      "[1, 2, 3]",
+			Proposal: "[1, 2, 3, !lock 8]",
+		},
+		{
+			Name:     "seq with dst inner lock",
+			Src:      "[1, 2, 3]",
+			Dst:      "[4, !lock 5, 6, 7, !lock 8]",
+			Joy:      "[1, 2, 3]",
+			Proposal: "[1, !lock 5, 3, !lock 8]",
+		},
+		{
+			Name:     "seq with src inner lock",
+			Src:      "[!lock 1, !lock 2, 3]",
+			Dst:      "[      4, !lock 5, 6, 7, !lock 8]",
+			Joy:      "[!lock TODO, !lock TODO, 3]",
+			Proposal: "[4, !lock 5, 3, !lock 8]",
+		},
+		{
+			Name:     "seq with locked dst",
+			Src:      "[1, 2, 3]",
+			Dst:      "!lock [4, 5, 6]",
+			Joy:      "[1, 2, 3]",
+			Proposal: "!lock [4, 5, 6]",
+		},
+		{
+			Name:     "map",
+			Src:      "{key: 5}",
+			Dst:      "{key: 3}",
+			Joy:      "{key: 5}",
+			Proposal: "{key: 5}",
+		},
+		{
+			Name:     "map disjoint",
+			Src:      "{key: 5}",
+			Dst:      "{value: 3}",
+			Joy:      "{key: 5}",
+			Proposal: "{key: 5}",
+		},
+		{
+			Name:     "map disjoint with dst lock",
+			Src:      "{key: 5}",
+			Dst:      "{value: !lock 3, foo: bar}",
+			Joy:      "{value: !lock 3, key: 5}",
+			Proposal: "{key: 5, value: !lock 3}",
+		},
+		{
+			Name:     "map with special keys",
+			Src:      "{key:1: a}",
+			Dst:      "{}",
+			Joy:      "{'key:1': a}",
+			Proposal: "{'key:1': a}",
+		},
+		{
+			Name:     "alias",
+			Src:      "{a: &one 1, b: *one}",
+			Dst:      "{a: &two 2, b: *two}",
+			Joy:      "{a: &one 1, b: *one}",
+			Proposal: "{a: &one 1, b: *one}",
+		},
+		{
+			Name:     "nested",
+			Src:      "{a: {b: {c: d}}}",
+			Dst:      "{a: {b: {c: e}}}",
+			Joy:      "{a: {b: {c: d}}}",
+			Proposal: "{a: {b: {c: d}}}",
+		},
+		{
+			Name:     "nested lock",
+			Src:      "{a: {b: {c: d}}}",
+			Dst:      "{a: {b: !lock {c: e}}}",
+			Joy:      "{a: {b: !lock {c: e}}}",
+			Proposal: "{a: {b: !lock {c: e}}}",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			var src, dst yaml.Node
+			require.NoError(t, yaml.Unmarshal([]byte(tc.Src), &src))
+			require.NoError(t, yaml.Unmarshal([]byte(tc.Dst), &dst))
+
+			{
+				actual, err := yaml.Marshal(yml.Merge(&src, &dst))
+				require.NoError(t, err)
+
+				actual = bytes.TrimSpace(actual)
+
+				require.Equal(t, tc.Joy, string(actual), "JOY")
+			}
+
+			{
+				actual, err := yaml.Marshal(promote.Merge(&dst, &src))
+				require.NoError(t, err)
+
+				actual = bytes.TrimSpace(actual)
+
+				require.Equal(t, tc.Proposal, string(actual), "PROPOSAL")
+			}
+		})
+	}
+}


### PR DESCRIPTION
The current implementation of Joy's yaml merge does not account for sequences, whether locked or containing locked values.

The current merge implementation is also not particularly easy to follow.

This PR proposes an alternative merge implementation and provides a suite of tests to outline the difference in output between the current and proposed implementation.

The proposed implementation does have one implementation caveat/simplification, which assumes that the only method to lock a node is via lock tags: `!lock`.

If the proposed implementation is greenlighted, work will be done to port it into the main `internal/yml` package and update existing test suites.

