### PR TITLE
fix(PL-1906): gha, fix handling of BREAKING

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -68,8 +68,9 @@ jobs:
 
       - name: Generate changelog and tag release
         id: changelog
-        uses: TriPSs/conventional-changelog-action@v4
+        uses: nestoca/conventional-changelog-action@releases/v4
         with:
+          preset: conventionalcommits # default is `angular` and does not support breaking changes of type feat!
           input-file: CHANGELOG.md
           output-file: CHANGELOG.md
           fallback-version: 0.0.0


### PR DESCRIPTION

Note that the action is the same code as nestoca/conventional-changelog-action@releases/v4, but we this way nobody can change the code and tag under our feet.