### PR TITLE
feat(PL-2290): allow secrets to be sealed from stdin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/mock v0.3.0
 	golang.org/x/mod v0.14.0
+	golang.org/x/term v0.14.0
 	gopkg.in/godo.v2 v2.0.9
 )
 
@@ -31,7 +32,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	golang.org/x/sys v0.14.0 // indirect
-	golang.org/x/term v0.14.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )


### PR DESCRIPTION
This PR makes the `joy secret seal` command compatible with unix pipes.

This makes sealing the content of files easier, and makes joy easier to script with.

Example:
```
# seal a file and add it to your clipboard!
cat credentials.json | joy secret seal -e qa | pbcopy
```


