### PR TITLE
fix(PL-2290): do not emit newline at end of sealed secret in non-ttl mode

### DIFF
--- a/internal/secret/seal.go
+++ b/internal/secret/seal.go
@@ -57,7 +57,7 @@ func Seal(cat *catalog.Catalog, opts SealOptions) error {
 	}
 
 	if !opts.OutputIsTTY {
-		fmt.Println(output)
+		fmt.Print(output)
 		return nil
 	}
 


### PR DESCRIPTION
When outputting the sealed secret to a file or to any unix pipe, we do not want to print the newline.

Newlines are for humans. We are in machine world now.