### PR TITLE
fix/PL 2314/replicate appset behaviour in release render

### DIFF
--- a/cmd/joy/release.go
+++ b/cmd/joy/release.go
@@ -227,14 +227,15 @@ func NewReleaseRenderCmd() *cobra.Command {
 			}
 
 			return render.Render(cmd.Context(), render.RenderOpts{
-				Env:          env,
-				Release:      releaseName,
-				DefaultChart: cfg.DefaultChart,
-				CacheDir:     cfg.JoyCache,
-				Catalog:      cat,
-				IO:           io,
-				Helm:         helm.CLI{IO: io},
-				Color:        color,
+				Env:           env,
+				Release:       releaseName,
+				DefaultChart:  cfg.DefaultChart,
+				CacheDir:      cfg.JoyCache,
+				ChartMappings: cfg.ChartMappings,
+				Catalog:       cat,
+				IO:            io,
+				Helm:          helm.CLI{IO: io},
+				Color:         color,
 			})
 		},
 	}

--- a/cmd/joy/release.go
+++ b/cmd/joy/release.go
@@ -227,15 +227,15 @@ func NewReleaseRenderCmd() *cobra.Command {
 			}
 
 			return render.Render(cmd.Context(), render.RenderOpts{
-				Env:           env,
-				Release:       releaseName,
-				DefaultChart:  cfg.DefaultChart,
-				CacheDir:      cfg.JoyCache,
-				ChartMappings: cfg.ChartMappings,
-				Catalog:       cat,
-				IO:            io,
-				Helm:          helm.CLI{IO: io},
-				Color:         color,
+				Env:          env,
+				Release:      releaseName,
+				DefaultChart: cfg.DefaultChart,
+				CacheDir:     cfg.JoyCache,
+				ValueMapping: cfg.ValueMapping,
+				Catalog:      cat,
+				IO:           io,
+				Helm:         helm.CLI{IO: io},
+				Color:        color,
 			})
 		},
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,16 @@ type Config struct {
 	// DefaultChart is the chart reference used by the catalog when omitted from the joy release
 	DefaultChart string `yaml:"defaultChart,omitempty"`
 
+	// ChartMappings are used to apply parameters to the chart values. The values of the mapping
+	// can use the Release and Environment as template values. Chart mappings will not override values
+	// already present in the chart
+	// For example:
+	//
+	//   image.tag: {{ .Release.Spec.Version }}
+	//   common.annotations.example\.com/custom: true
+	//
+	ChartMappings map[string]any `yaml:"chartMappings,omitempty"`
+
 	// FilePath is the path to the config file that was loaded, used to write back to the same file.
 	FilePath string `yaml:"-"`
 
@@ -102,6 +112,10 @@ func Load(configDir, catalogDir string) (*Config, error) {
 
 	if catalogCfg.DefaultChart != "" {
 		cfg.DefaultChart = catalogCfg.DefaultChart
+	}
+
+	if catalogCfg.ChartMappings != nil {
+		cfg.ChartMappings = catalogCfg.ChartMappings
 	}
 
 	if cfg.MinVersion != "" && !semver.IsValid(cfg.MinVersion) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,7 +33,7 @@ type Config struct {
 	// DefaultChart is the chart reference used by the catalog when omitted from the joy release
 	DefaultChart string `yaml:"defaultChart,omitempty"`
 
-	// ChartMappings are used to apply parameters to the chart values. The values of the mapping
+	// ValueMapping are used to apply parameters to the chart values. The values of the mapping
 	// can use the Release and Environment as template values. Chart mappings will not override values
 	// already present in the chart
 	// For example:
@@ -41,7 +41,7 @@ type Config struct {
 	//   image.tag: {{ .Release.Spec.Version }}
 	//   common.annotations.example\.com/custom: true
 	//
-	ChartMappings map[string]any `yaml:"chartMappings,omitempty"`
+	ValueMapping map[string]any `yaml:"valueMapping,omitempty"`
 
 	// FilePath is the path to the config file that was loaded, used to write back to the same file.
 	FilePath string `yaml:"-"`
@@ -114,8 +114,8 @@ func Load(configDir, catalogDir string) (*Config, error) {
 		cfg.DefaultChart = catalogCfg.DefaultChart
 	}
 
-	if catalogCfg.ChartMappings != nil {
-		cfg.ChartMappings = catalogCfg.ChartMappings
+	if catalogCfg.ValueMapping != nil {
+		cfg.ValueMapping = catalogCfg.ValueMapping
 	}
 
 	if cfg.MinVersion != "" && !semver.IsValid(cfg.MinVersion) {

--- a/internal/release/render/render_test.go
+++ b/internal/release/render/render_test.go
@@ -24,7 +24,7 @@ func TestRender(t *testing.T) {
 		Catalog       *catalog.Catalog
 		IO            internal.IO
 		SetupHelmMock func(*helm.MockPullRenderer)
-		ChartMappings map[string]any
+		ValueMapping  map[string]any
 	}
 
 	var (
@@ -313,7 +313,7 @@ func TestRender(t *testing.T) {
 						},
 					},
 				},
-				ChartMappings: map[string]any{
+				ValueMapping: map[string]any{
 					"image.tag":             "{{ .Release.Spec.Version }}",
 					`annotations.nesto\.ca`: true,
 				},
@@ -366,15 +366,15 @@ func TestRender(t *testing.T) {
 			}
 
 			err := Render(context.Background(), RenderOpts{
-				Env:           tc.Params.Env,
-				Release:       tc.Params.Release,
-				DefaultChart:  tc.Params.DefaultChart,
-				CacheDir:      tc.Params.CacheDir,
-				ChartMappings: tc.Params.ChartMappings,
-				Catalog:       tc.Params.Catalog,
-				IO:            io,
-				Helm:          helmMock,
-				Color:         false,
+				Env:          tc.Params.Env,
+				Release:      tc.Params.Release,
+				DefaultChart: tc.Params.DefaultChart,
+				CacheDir:     tc.Params.CacheDir,
+				ValueMapping: tc.Params.ValueMapping,
+				Catalog:      tc.Params.Catalog,
+				IO:           io,
+				Helm:         helmMock,
+				Color:        false,
 			})
 			if tc.ExpectedError != "" {
 				require.EqualError(t, err, tc.ExpectedError)

--- a/internal/release/render/render_test.go
+++ b/internal/release/render/render_test.go
@@ -219,12 +219,14 @@ func TestRender(t *testing.T) {
 							Values: map[string]any{
 								"env":     "{{ .Environment.Name `!}}",
 								"version": "{{ .Release.Spec.Version }}",
+								"image":   map[string]any{"tag": "v1.2.3"},
+								"common":  map[string]any{"annotations": map[string]any{"nesto.ca/deployed-by": "joy"}},
 							},
 						}).
 						Return(nil)
 				},
 			},
-			ExpectedOut: "error hydrating values: template: :1: unterminated raw quoted string\nfallback to raw release.spec.values\n",
+			ExpectedOut: "error hydrating values: template: :4: unterminated raw quoted string\nfallback to raw release.spec.values\n",
 		},
 		{
 			Name: "fail to render",
@@ -275,6 +277,8 @@ func TestRender(t *testing.T) {
 							Values: map[string]any{
 								"env":     "qa",
 								"version": "v1.2.3",
+								"image":   map[string]any{"tag": "v1.2.3"},
+								"common":  map[string]any{"annotations": map[string]any{"nesto.ca/deployed-by": "joy"}},
 							},
 						}).
 						Return(errors.New("bebop"))

--- a/pkg/values.go
+++ b/pkg/values.go
@@ -1,0 +1,11 @@
+package joy
+
+import (
+	"github.com/nestoca/joy/api/v1alpha1"
+	"github.com/nestoca/joy/internal/release/render"
+)
+
+// ReleaseValues returns the values from a Release.Spec.Values after all chart mappings have been applied and templated values subsituted.
+func ReleaseValues(release *v1alpha1.Release, environment *v1alpha1.Environment, mappings map[string]any) (map[string]any, error) {
+	return render.HydrateValues(release, environment, mappings)
+}


### PR DESCRIPTION
This replicates the ApplicationSet defaults in release rendering. The only omission is `release.spec.versionKey` because it is not captured in the v1alpha1.Release definition. However nobody uses it the catalog so its ok to omit for now.