### PR TITLE
feat(PL-2372): add joy.LoadCatalogConfig to joy sdk

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	joyrcFile     = ".joyrc"
-	joyDefaultDir = ".joy"
+	JoyrcFile     = ".joyrc"
+	JoyDefaultDir = ".joy"
 )
 
 type Config struct {
@@ -77,7 +77,7 @@ func Load(configDir, catalogDir string) (*Config, error) {
 	}
 
 	// Load config from .joyrc in configDir
-	joyrcPath := filepath.Join(configDir, joyrcFile)
+	joyrcPath := filepath.Join(configDir, JoyrcFile)
 
 	cfg, err := LoadFile(joyrcPath)
 	if err != nil {
@@ -96,10 +96,10 @@ func Load(configDir, catalogDir string) (*Config, error) {
 	}
 
 	if cfg.CatalogDir == "" {
-		cfg.CatalogDir = filepath.Join(homeDir, joyDefaultDir)
+		cfg.CatalogDir = filepath.Join(homeDir, JoyDefaultDir)
 	}
 
-	catalogJoyrc := filepath.Join(cfg.CatalogDir, joyrcFile)
+	catalogJoyrc := filepath.Join(cfg.CatalogDir, JoyrcFile)
 
 	catalogCfg, err := LoadFile(catalogJoyrc)
 	if err != nil {

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -1,0 +1,15 @@
+package joy
+
+import (
+	"path/filepath"
+
+	"github.com/nestoca/joy/internal/config"
+)
+
+type Config = config.Config
+
+// LoadCatalogConfig takes the path to the catalog as input and loads any catalog specific
+// configuration found in its .joyrc
+func LoadCatalogConfig(catalogPath string) (*Config, error) {
+	return config.LoadFile(filepath.Join(catalogPath, config.JoyrcFile))
+}


### PR DESCRIPTION
This change is being made so that the `joy-generator` can conveniently load joy catalog configuration.
This will allow the joy-generator to use values set in the catalog instead of hardcoding specific defaults/behaviour.