### PR TITLE
feat: add support for catalog.yaml

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	CatalogConfigFile = "catalog.yaml"
+	CatalogConfigFile = "joy.yaml"
 	JoyrcFile         = ".joyrc"
 	JoyDefaultDir     = ".joy"
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	JoyrcFile     = ".joyrc"
-	JoyDefaultDir = ".joy"
+	CatalogConfigFile = "catalog.yaml"
+	JoyrcFile         = ".joyrc"
+	JoyDefaultDir     = ".joy"
 )
 
 type Config struct {
@@ -40,7 +41,7 @@ type Config struct {
 
 	// ValueMapping are used to apply parameters to the chart values. The values of the mapping
 	// can use the Release and Environment as template values. Chart mappings will not override values
-	// already present in the chart
+	// already present in the chart.
 	// For example:
 	//
 	//   image.tag: {{ .Release.Spec.Version }}
@@ -104,9 +105,17 @@ func Load(configDir, catalogDir string) (*Config, error) {
 		cfg.CatalogDir = filepath.Join(homeDir, JoyDefaultDir)
 	}
 
-	catalogJoyrc := filepath.Join(cfg.CatalogDir, JoyrcFile)
+	catalogConfigFilepath := ""
+	// TODO: Removed once everybody is using a version of joy that supports the new catalog.yaml
+	// After: 2024-04-16
+	for _, filename := range []string{CatalogConfigFile, JoyrcFile} {
+		if _, err := os.Stat(cfg.CatalogDir); err != nil {
+			catalogConfigFilepath = filepath.Join(cfg.CatalogDir, filename)
+			break
+		}
+	}
 
-	catalogCfg, err := LoadFile(catalogJoyrc)
+	catalogCfg, err := LoadFile(catalogConfigFilepath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load catalog configuration: %w", err)
 	}


### PR DESCRIPTION

Somewhat of a proposal, I think having an hidden file `.joyrc` in the `catalog` is a great idea, but I think it should be visible (easily) to the user so I am proposing we rename it to `catalog.yaml`.

Any other name is welcome.