### PR TITLE
feat(PL-2419): add support for alternate names for catalog/joy.yaml

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	JoyrcFile     = ".joyrc"
-	JoyDefaultDir = ".joy"
+	CatalogConfigFile = "joy.yaml"
+	JoyrcFile         = ".joyrc"
+	JoyDefaultDir     = ".joy"
 )
 
 type Config struct {
@@ -40,7 +41,7 @@ type Config struct {
 
 	// ValueMapping are used to apply parameters to the chart values. The values of the mapping
 	// can use the Release and Environment as template values. Chart mappings will not override values
-	// already present in the chart
+	// already present in the chart.
 	// For example:
 	//
 	//   image.tag: {{ .Release.Spec.Version }}
@@ -139,9 +140,9 @@ func Load(configDir, catalogDir string) (*Config, error) {
 		cfg.CatalogDir = filepath.Join(homeDir, JoyDefaultDir)
 	}
 
-	catalogJoyrc := filepath.Join(cfg.CatalogDir, JoyrcFile)
+	catalogConfigPath := filepath.Join(cfg.CatalogDir, CatalogConfigFile)
 
-	catalogCfg, err := LoadFile(catalogJoyrc)
+	catalogCfg, err := LoadFile(catalogConfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load catalog configuration: %w", err)
 	}


### PR DESCRIPTION
I have renamed the file to `joy.yaml` as discussed in https://github.com/nestoca/joy/pull/88

I also have tested using a symlink and it was handled gracefully
by `joy` as-is.

So we can just do: https://github.com/nestoca/catalog/pull/597

And delete the symlink in a few months or so.

