### PR TITLE
fix: git, ignore hooks when committing

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -133,7 +133,7 @@ func Add(dir string, files []string) error {
 }
 
 func Commit(dir, message string) error {
-	cmd := exec.Command("git", "-C", dir, "commit", "-m", message)
+	cmd := exec.Command("git", "-C", dir, "commit", "--no-verify", "-m", message)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		fmt.Println(string(output))


### PR DESCRIPTION
@jsbejeau is using global commit hooks, which is interfering with committing the changes with `joy release promote.`

Context: https://nestomortgage.slack.com/archives/C04ADN73SPL/p1708474214393809?thread_ts=1708468838.434969&cid=C04ADN73SPL