### PR TITLE
fix: tell people to run `brew update` first

### DIFF
--- a/internal/diagnostics/executable.go
+++ b/internal/diagnostics/executable.go
@@ -39,7 +39,7 @@ func diagnoseExecutable(cfg *config.Config, cliVersion string, opts ExecutableOp
 		group.AddMsg(
 			failed,
 			fmt.Sprintf("Version does not meet minimum of %s required by catalog", style.Code(cfg.MinVersion)),
-			msg(hint, fmt.Sprintf("Update joy using: %s", style.Code("brew upgrade joy"))),
+			msg(hint, fmt.Sprintf("Update joy using: %s", style.Code("brew update && brew upgrade joy"))),
 		)
 		return
 	}

--- a/internal/diagnostics/executable_test.go
+++ b/internal/diagnostics/executable_test.go
@@ -69,7 +69,7 @@ func TestExecutableDiagnostics(t *testing.T) {
 						Type:  "failed",
 						Value: "Version does not meet minimum of v2.0.0 required by catalog",
 						Details: Messages{
-							{Type: "hint", Value: "Update joy using: brew upgrade joy"},
+							{Type: "hint", Value: "Update joy using: brew update && brew upgrade joy"},
 						},
 					},
 				},


### PR DESCRIPTION

Otherwise we depend on the state of brew's cache.