### PR TITLE
fix(PL-2247): GoRelease github token

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -111,4 +111,4 @@ jobs:
           version: latest
           args: release --clean --release-notes "${{ runner.temp }}/CHANGELOG.md"
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_HOMEBREW_PUBLISHER }}
+          GITHUB_TOKEN: ${{ secrets.GH_HOMEBREW_PUBLIC_TOKEN }}


### PR DESCRIPTION
Publish step is currently failing:
https://github.com/nestoca/joy/actions/runs/8116624287/job/22187126046