### PR TITLE
feat(PL-2247): add labels and CODEOWNERS to PR

### DIFF
--- a/api/v1alpha1/project.go
+++ b/api/v1alpha1/project.go
@@ -23,8 +23,13 @@ type ProjectMetadata struct {
 
 type ProjectSpec struct {
 	// Owners is the list of identifiers of owners of the project.
-	// It can be any strings that uniquely identifies the owners, such as email addresses or Jac group identifiers.
+	// It can be any string that uniquely identifies the owners, such as email addresses or Jac group identifiers.
 	Owners []string `yaml:"owners,omitempty" json:"owners,omitempty"`
+
+	// CodeOwners is the list of GitHub Code Owners of the project.
+	// This gets added to the CODEOWNERS file from the repository.
+	// Unlike Owners above which are based on Jac, they are GitHub usernames or teams.
+	CodeOwners []string `yaml:"codeOwners,omitempty" json:"codeOwners,omitempty"`
 
 	// Git repository of the project.
 	Repository string `yaml:"repository,omitempty" json:"repository,omitempty"`

--- a/internal/release/promote/github_codeowners.go
+++ b/internal/release/promote/github_codeowners.go
@@ -1,0 +1,48 @@
+package promote
+
+import (
+	"os"
+	"strings"
+)
+
+func GetCodeOwners(dir string) ([]string, error) {
+	var owners []string
+	for _, relativeFilepath := range []string{".github/CODEOWNERS", "CODEOWNERS"} {
+		filepath := dir + "/" + relativeFilepath
+		_, err := os.Stat(filepath)
+		if err != nil {
+			continue
+		}
+		content, err := os.ReadFile(filepath)
+		if err != nil {
+			return nil, err
+		}
+		owners = append(owners, parseCodeOwners(string(content))...)
+	}
+	return owners, nil
+}
+
+func parseCodeOwners(content string) []string {
+	var owners []string
+	lines := strings.Split(content, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		parts := strings.Split(line, " ")
+		if len(parts) < 2 {
+			continue
+		}
+
+		for _, owner := range parts[1:] {
+			if owner == "" {
+				continue
+			}
+			owners = append(owners, strings.TrimLeft(owner, "@"))
+		}
+	}
+
+	return owners
+}

--- a/internal/release/promote/github_codeowners_test.go
+++ b/internal/release/promote/github_codeowners_test.go
@@ -1,0 +1,35 @@
+package promote
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPromotion(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		content  string
+		expected []string
+	}{
+		{
+			name:     "one-line",
+			content:  "src/ @dj-martin @davidmdm @ayahajar @silphid",
+			expected: []string{"dj-martin", "davidmdm", "ayahajar", "silphid"},
+		},
+		{
+			name:     "multi-line",
+			content:  "* @ayahajar\n\n\n* @dcpantalone\n",
+			expected: []string{"ayahajar", "dcpantalone"},
+		},
+		{
+			name:     "withcomments",
+			content:  "# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners for syntax\n\n\n*   @dj-martin @davidmdm @ayahajar @silphid",
+			expected: []string{"dj-martin", "davidmdm", "ayahajar", "silphid"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.ElementsMatchf(t, parseCodeOwners(tc.content), tc.expected, "owners should match")
+		})
+	}
+}

--- a/internal/release/promote/test/integration_test.go
+++ b/internal/release/promote/test/integration_test.go
@@ -45,6 +45,9 @@ var (
 	simpleReleaseGitTagFunc = func(release *v1alpha1.Release) (string, error) {
 		return "v" + release.Spec.Version, nil
 	}
+	simpleGetCodeOwnersFunc = func(dir string) ([]string, error) {
+		return []string{"nestobot"}, nil
+	}
 )
 
 func TestPromoteAllReleasesFromStagingToProd(t *testing.T) {
@@ -83,9 +86,7 @@ func TestPromoteAllReleasesFromStagingToProd(t *testing.T) {
 	targetEnv.Spec.Promotion.AllowAutoMerge = true
 
 	// Perform test
-	promotion := promote.NewPromotion(promptProvider, promote.NewShellGitProvider(dir), github.NewPullRequestProvider(dir),
-		&promote.FileSystemYamlWriter{}, simpleCommitTemplate, simplePullRequestTemplate, simpleProjectRepositoryFunc, simpleProjectSourceDirFunc,
-		simpleCommitsMetadataFunc, simpleCommitsGitHubAuthorsFunc, simpleReleaseGitTagFunc)
+	promotion := promote.NewPromotion(promptProvider, promote.NewShellGitProvider(dir), github.NewPullRequestProvider(dir), &promote.FileSystemYamlWriter{}, simpleCommitTemplate, simplePullRequestTemplate, simpleProjectRepositoryFunc, simpleProjectSourceDirFunc, simpleCommitsMetadataFunc, simpleCommitsGitHubAuthorsFunc, simpleReleaseGitTagFunc, simpleGetCodeOwnersFunc)
 	opts := promote.Opts{
 		Catalog:   cat,
 		SourceEnv: sourceEnv,
@@ -137,9 +138,7 @@ func TestPromoteAutoMergeFromStagingToProd(t *testing.T) {
 	targetEnv.Spec.Promotion.AllowAutoMerge = true
 
 	// Perform test
-	promotion := promote.NewPromotion(promptProvider, promote.NewShellGitProvider(dir), github.NewPullRequestProvider(dir),
-		&promote.FileSystemYamlWriter{}, simpleCommitTemplate, simplePullRequestTemplate, simpleProjectRepositoryFunc, simpleProjectSourceDirFunc,
-		simpleCommitsMetadataFunc, simpleCommitsGitHubAuthorsFunc, simpleReleaseGitTagFunc)
+	promotion := promote.NewPromotion(promptProvider, promote.NewShellGitProvider(dir), github.NewPullRequestProvider(dir), &promote.FileSystemYamlWriter{}, simpleCommitTemplate, simplePullRequestTemplate, simpleProjectRepositoryFunc, simpleProjectSourceDirFunc, simpleCommitsMetadataFunc, simpleCommitsGitHubAuthorsFunc, simpleReleaseGitTagFunc, simpleGetCodeOwnersFunc)
 
 	opts := promote.Opts{
 		Catalog:   cat,
@@ -154,7 +153,7 @@ func TestPromoteAutoMergeFromStagingToProd(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, prURL)
 
-	require.Equal(t, []string{"auto-merge"}, getPullRequestLabels(t, dir, prURL))
+	require.Equal(t, []string{"auto-merge", "environment:prod", "release:bar", "release:foo"}, getPullRequestLabels(t, dir, prURL))
 }
 
 func TestEnforceEnvironmentAllowAutoMerge(t *testing.T) {
@@ -177,9 +176,7 @@ func TestEnforceEnvironmentAllowAutoMerge(t *testing.T) {
 	targetEnv.Spec.Promotion.AllowAutoMerge = false
 
 	// Perform test
-	promotion := promote.NewPromotion(nil, promote.NewShellGitProvider(dir), github.NewPullRequestProvider(dir),
-		&promote.FileSystemYamlWriter{}, simpleCommitTemplate, simplePullRequestTemplate, simpleProjectRepositoryFunc, simpleProjectSourceDirFunc,
-		simpleCommitsMetadataFunc, simpleCommitsGitHubAuthorsFunc, simpleReleaseGitTagFunc)
+	promotion := promote.NewPromotion(nil, promote.NewShellGitProvider(dir), github.NewPullRequestProvider(dir), &promote.FileSystemYamlWriter{}, simpleCommitTemplate, simplePullRequestTemplate, simpleProjectRepositoryFunc, simpleProjectSourceDirFunc, simpleCommitsMetadataFunc, simpleCommitsGitHubAuthorsFunc, simpleReleaseGitTagFunc, simpleGetCodeOwnersFunc)
 
 	opts := promote.Opts{
 		Catalog:   cat,
@@ -265,9 +262,7 @@ func TestDraftPromoteFromStagingToProd(t *testing.T) {
 	targetEnv.Spec.Promotion.AllowAutoMerge = true
 
 	// Perform test
-	promotion := promote.NewPromotion(promptProvider, promote.NewShellGitProvider(dir), github.NewPullRequestProvider(dir),
-		&promote.FileSystemYamlWriter{}, simpleCommitTemplate, simplePullRequestTemplate, simpleProjectRepositoryFunc, simpleProjectSourceDirFunc,
-		simpleCommitsMetadataFunc, simpleCommitsGitHubAuthorsFunc, simpleReleaseGitTagFunc)
+	promotion := promote.NewPromotion(promptProvider, promote.NewShellGitProvider(dir), github.NewPullRequestProvider(dir), &promote.FileSystemYamlWriter{}, simpleCommitTemplate, simplePullRequestTemplate, simpleProjectRepositoryFunc, simpleProjectSourceDirFunc, simpleCommitsMetadataFunc, simpleCommitsGitHubAuthorsFunc, simpleReleaseGitTagFunc, simpleGetCodeOwnersFunc)
 
 	opts := promote.Opts{
 		Catalog:   cat,

--- a/internal/release/promote/test/promotion_test.go
+++ b/internal/release/promote/test/promotion_test.go
@@ -61,6 +61,9 @@ func TestPromotion(t *testing.T) {
 	simpleReleaseGitTagFunc := func(release *v1alpha1.Release) (string, error) {
 		return "v" + release.Spec.Version, nil
 	}
+	simpleGetCodeOwnersFunc := func(dir string) ([]string, error) {
+		return []string{"nestobot"}, nil
+	}
 
 	cases := []struct {
 		name                        string
@@ -73,6 +76,7 @@ func TestPromotion(t *testing.T) {
 		getCommitsMetadataFunc      func(projectDir, from, to string) ([]*promote.CommitMetadata, error)
 		getCommitsGitHubAuthorsFunc func(proj *v1alpha1.Project, fromTag, toTag string) (map[string]string, error)
 		getReleaseGitTagFunc        func(release *v1alpha1.Release) (string, error)
+		getCodeOwnersFunc           func(dir string) ([]string, error)
 		expectedErrorMessage        string
 		expectedPromoted            bool
 	}{
@@ -168,6 +172,7 @@ func TestPromotion(t *testing.T) {
 			getCommitsMetadataFunc:      simpleCommitsMetadataFunc,
 			getCommitsGitHubAuthorsFunc: simpleCommitsGitHubAuthorsFunc,
 			getReleaseGitTagFunc:        simpleReleaseGitTagFunc,
+			getCodeOwnersFunc:           simpleGetCodeOwnersFunc,
 			expectedPromoted:            true,
 		},
 		{
@@ -224,6 +229,7 @@ func TestPromotion(t *testing.T) {
 			getCommitsMetadataFunc:      simpleCommitsMetadataFunc,
 			getCommitsGitHubAuthorsFunc: simpleCommitsGitHubAuthorsFunc,
 			getReleaseGitTagFunc:        simpleReleaseGitTagFunc,
+			getCodeOwnersFunc:           simpleGetCodeOwnersFunc,
 			expectedPromoted:            true,
 		},
 	}
@@ -248,9 +254,7 @@ func TestPromotion(t *testing.T) {
 			})
 
 			// Perform test
-			promotion := promote.NewPromotion(promptProvider, gitProvider, prProvider, yamlWriter, c.commitTemplate, c.pullRequestTemplate,
-				c.getProjectRepositoryFunc, c.getProjectSourceDirFunc, c.getCommitsMetadataFunc, c.getCommitsGitHubAuthorsFunc,
-				c.getReleaseGitTagFunc)
+			promotion := promote.NewPromotion(promptProvider, gitProvider, prProvider, yamlWriter, c.commitTemplate, c.pullRequestTemplate, c.getProjectRepositoryFunc, c.getProjectSourceDirFunc, c.getCommitsMetadataFunc, c.getCommitsGitHubAuthorsFunc, c.getReleaseGitTagFunc, c.getCodeOwnersFunc)
 			prURL, err := promotion.Promote(c.opts)
 
 			// Check expected results


### PR DESCRIPTION
Example: https://github.com/nestoca/catalog/pull/1095

```
$ JOY_DEV_SKIP_VERSION_CHECK=1 go run ./cmd/joy release promote --dry-run --skip-catalog-update --draft --no-prompt --source qa --target production creditreports
Promote creditreports 0.65.0 -> 0.65.0 (qa -> production)
# Promotions
| Release | Diff | Source: qa | Target: production |
|:---|:---|:---|:---|
| `creditreports` | [Downgrade](https://github.com/nestoca/creditreports/compare/api/v0.65.0...api/v0.65.0) | 0.65.0 <br> [Argo CD](https://argocd.platform.nesto.ca/applications/argocd/qa-creditreports) <br> [Datadog](https://app.datadoghq.com/logs?query=env%3Aqa%20service%3Acreditreports&cols=env%2Cservice) | 0.65.0 <br> [Argo CD](https://argocd.platform.nesto.ca/applications/argocd/production-creditreports) <br> [Datadog](https://app.datadoghq.com/logs?query=env%3Aproduction%20service%3Acreditreports&cols=env%2Cservice) |

# Downgrade commits for `creditreports`
No commits found.
Reviewers:
- adegiamb-nesto
- oscar-nesto
Labels
- environment:production
- release:creditreports
```