### PR TITLE
fix(PL-2247): expand pr numbers to explicit links

### DIFF
--- a/internal/release/promote/inject_pr_links.go
+++ b/internal/release/promote/inject_pr_links.go
@@ -1,0 +1,22 @@
+package promote
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var pullRequestReferenceRegex = regexp.MustCompile(`(?m)(^|\s)#(\d+)\b`)
+
+func injectPullRequestLinks(repo string, text string) (string, error) {
+	// Iterate over the matches in reverse order, to prevent replacement from offsetting indexes
+	matches := pullRequestReferenceRegex.FindAllStringSubmatchIndex(text, -1)
+	for i := len(matches) - 1; i >= 0; i-- {
+		match := matches[i]
+		prefix := text[match[2]:match[3]]
+		prNumber := text[match[4]:match[5]]
+		replacement := fmt.Sprintf("[#%s](https://github.com/%s/pull/%s)", prNumber, repo, prNumber)
+		text = text[:match[0]] + prefix + replacement + text[match[1]:]
+	}
+
+	return text, nil
+}

--- a/internal/release/promote/inject_pr_links_test.go
+++ b/internal/release/promote/inject_pr_links_test.go
@@ -1,0 +1,72 @@
+package promote
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInjectPullRequestLinks(t *testing.T) {
+	template := `[#{{ .PullRequestNumber }}](https://github.com/{{ .Repository }}/pull/{{ .PullRequestNumber }})`
+	repository := "acme/project"
+
+	tests := []struct {
+		name     string
+		template string
+		text     string
+		expected string
+	}{
+		{
+			name:     "empty",
+			template: template,
+			text:     "",
+			expected: "",
+		},
+		{
+			name:     "no pr number",
+			template: template,
+			text:     "no pr number",
+			expected: "no pr number",
+		},
+		{
+			name:     "just pr number",
+			template: template,
+			text:     "#123",
+			expected: "[#123](https://github.com/acme/project/pull/123)",
+		},
+		{
+			name:     "pr number in the middle",
+			template: template,
+			text:     "text #123 text",
+			expected: "text [#123](https://github.com/acme/project/pull/123) text",
+		},
+		{
+			name:     "multiple pr numbers on different lines",
+			template: template,
+			text:     "text #123 text\ntext #456 text",
+			expected: "text [#123](https://github.com/acme/project/pull/123) text\n" +
+				"text [#456](https://github.com/acme/project/pull/456) text",
+		},
+		{
+			name:     "multiple pr numbers on the same line",
+			template: template,
+			text:     "text #123 text #456 text",
+			expected: "text [#123](https://github.com/acme/project/pull/123) text [#456](https://github.com/acme/project/pull/456) text",
+		},
+		{
+			name:     "non-pr numbers",
+			template: template,
+			text:     "text#123 text1#123 #123text",
+			expected: "text#123 text1#123 #123text",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := injectPullRequestLinks(repository, tt.text)
+			require.NoError(t, err)
+
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/internal/release/promote/test/promotion_test.go
+++ b/internal/release/promote/test/promotion_test.go
@@ -71,6 +71,7 @@ func TestPromotion(t *testing.T) {
 		setup                       func(args setupArgs)
 		commitTemplate              string
 		pullRequestTemplate         string
+		pullRequestLinkTemplate     string
 		getProjectRepositoryFunc    func(proj *v1alpha1.Project) string
 		getProjectSourceDirFunc     func(proj *v1alpha1.Project) (string, error)
 		getCommitsMetadataFunc      func(projectDir, from, to string) ([]*promote.CommitMetadata, error)


### PR DESCRIPTION
This is a fix to expand PR numbers (such as "#123") in commit messages of different projects into explicit PR links, because otherwise GitHub will automatically convert those PR numbers that it finds in promotion PR description into links to PRs within the catalog repository, whereas those PRs are actually located in the project repositories.

Requires this other PR to be merged before:
https://github.com/nestoca/catalog/pull/1161

# Example

Check both `#32` links below, first is automatically converted by GH to a link that points to PR `#32` on this `joy` repo (incorrect!), second is explicitly pointing to correct `audittrail` repo.

## Before
| Message | Author | Commit |
|:---|:---|:---|
| Merge pull request #32 from nestoca/chore/PL-2275/migrate-audittrail-production | @j-martin | [883df85](https://github.com/nestoca/audittrail/commit/883df859c5f65713435d1eb2951764b23e45348c) |

## After
| Message | Author | Commit |
|:---|:---|:---|
| Merge pull request [#32](https://github.com/nestoca/audittrail/pull/32) from nestoca/chore/PL-2275/migrate-audittrail-production | @j-martin | [883df85](https://github.com/nestoca/audittrail/commit/883df859c5f65713435d1eb2951764b23e45348c) |
