### PR TITLE
fix(PL-2463): ensure catalog is at origin head

### DIFF
--- a/cmd/joy/environment.go
+++ b/cmd/joy/environment.go
@@ -20,7 +20,6 @@ func NewEnvironmentCmd() *cobra.Command {
 }
 
 func NewEnvironmentSelectCmd() *cobra.Command {
-	var skipCatalogUpdate bool
 	allFlag := false
 	cmd := &cobra.Command{
 		Use:     "select",
@@ -31,7 +30,8 @@ func NewEnvironmentSelectCmd() *cobra.Command {
 Only selected environments will be included in releases table columns.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := config.FromContext(cmd.Context())
-			return environment.ConfigureSelection(cfg.CatalogDir, cfg.FilePath, allFlag, skipCatalogUpdate)
+			globalFlags := config.FromFlagContext(cmd.Context())
+			return environment.ConfigureSelection(cfg.CatalogDir, cfg.FilePath, allFlag, globalFlags.SkipCatalogUpdate)
 		},
 	}
 	cmd.Flags().BoolVarP(&allFlag, "all", "a", false, "Select all environments")

--- a/cmd/joy/environment.go
+++ b/cmd/joy/environment.go
@@ -20,6 +20,7 @@ func NewEnvironmentCmd() *cobra.Command {
 }
 
 func NewEnvironmentSelectCmd() *cobra.Command {
+	var skipCatalogUpdate bool
 	allFlag := false
 	cmd := &cobra.Command{
 		Use:     "select",
@@ -30,7 +31,7 @@ func NewEnvironmentSelectCmd() *cobra.Command {
 Only selected environments will be included in releases table columns.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := config.FromContext(cmd.Context())
-			return environment.ConfigureSelection(cfg.CatalogDir, cfg.FilePath, allFlag)
+			return environment.ConfigureSelection(cfg.CatalogDir, cfg.FilePath, allFlag, skipCatalogUpdate)
 		},
 	}
 	cmd.Flags().BoolVarP(&allFlag, "all", "a", false, "Select all environments")

--- a/cmd/joy/environment.go
+++ b/cmd/joy/environment.go
@@ -28,10 +28,12 @@ func NewEnvironmentSelectCmd() *cobra.Command {
 		Long: `Choose environments to work with and to promote from and to.
 
 Only selected environments will be included in releases table columns.`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return checkCatalogUpdateFlag(cmd)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := config.FromContext(cmd.Context())
-			globalFlags := config.FromFlagContext(cmd.Context())
-			return environment.ConfigureSelection(cfg.CatalogDir, cfg.FilePath, allFlag, globalFlags.SkipCatalogUpdate)
+			return environment.ConfigureSelection(cfg.CatalogDir, cfg.FilePath, allFlag)
 		},
 	}
 	cmd.Flags().BoolVarP(&allFlag, "all", "a", false, "Select all environments")

--- a/cmd/joy/environment.go
+++ b/cmd/joy/environment.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/nestoca/joy/internal/git"
 	"github.com/spf13/cobra"
 
 	"github.com/nestoca/joy/internal/config"
@@ -29,7 +30,7 @@ func NewEnvironmentSelectCmd() *cobra.Command {
 
 Only selected environments will be included in releases table columns.`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return checkCatalogUpdateFlag(cmd)
+			return git.EnsureCleanAndUpToDateWorkingCopy(cmd.Context())
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := config.FromContext(cmd.Context())

--- a/cmd/joy/project.go
+++ b/cmd/joy/project.go
@@ -22,7 +22,6 @@ func NewProjectCmd() *cobra.Command {
 }
 
 func NewProjectPeopleCmd() *cobra.Command {
-	var skipCatalogUpdate bool
 	cmd := &cobra.Command{
 		Use:   "owners",
 		Short: "List people owning a project via jac cli",
@@ -43,14 +42,14 @@ This command requires the jac cli: https://github.com/nestoca/jac
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := config.FromContext(cmd.Context())
-			return jac.ListProjectPeople(cfg.CatalogDir, args, skipCatalogUpdate)
+			globalFlags := config.FromFlagContext(cmd.Context())
+			return jac.ListProjectPeople(cfg.CatalogDir, args, globalFlags.SkipCatalogUpdate)
 		},
 	}
 	return cmd
 }
 
 func NewProjectListCmd() *cobra.Command {
-	var skipCatalogUpdate bool
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List projects and their owners",
@@ -60,7 +59,8 @@ func NewProjectListCmd() *cobra.Command {
 		Long: `List projects and their owners.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := config.FromContext(cmd.Context())
-			return project.List(cfg.CatalogDir, skipCatalogUpdate)
+			globalFlags := config.FromFlagContext(cmd.Context())
+			return project.List(cfg.CatalogDir, globalFlags.SkipCatalogUpdate)
 		},
 	}
 	return cmd

--- a/cmd/joy/project.go
+++ b/cmd/joy/project.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/nestoca/joy/internal/git"
 	"github.com/spf13/cobra"
 
 	"github.com/nestoca/joy/internal/config"
@@ -41,7 +42,7 @@ This command requires the jac cli: https://github.com/nestoca/jac
 		Args:               cobra.ArbitraryArgs,
 		DisableFlagParsing: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return checkCatalogUpdateFlag(cmd)
+			return git.EnsureCleanAndUpToDateWorkingCopy(cmd.Context())
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := config.FromContext(cmd.Context())
@@ -60,7 +61,7 @@ func NewProjectListCmd() *cobra.Command {
 		},
 		Long: `List projects and their owners.`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return checkCatalogUpdateFlag(cmd)
+			return git.EnsureCleanAndUpToDateWorkingCopy(cmd.Context())
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := config.FromContext(cmd.Context())

--- a/cmd/joy/project.go
+++ b/cmd/joy/project.go
@@ -22,6 +22,7 @@ func NewProjectCmd() *cobra.Command {
 }
 
 func NewProjectPeopleCmd() *cobra.Command {
+	var skipCatalogUpdate bool
 	cmd := &cobra.Command{
 		Use:   "owners",
 		Short: "List people owning a project via jac cli",
@@ -42,13 +43,14 @@ This command requires the jac cli: https://github.com/nestoca/jac
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := config.FromContext(cmd.Context())
-			return jac.ListProjectPeople(cfg.CatalogDir, args)
+			return jac.ListProjectPeople(cfg.CatalogDir, args, skipCatalogUpdate)
 		},
 	}
 	return cmd
 }
 
 func NewProjectListCmd() *cobra.Command {
+	var skipCatalogUpdate bool
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List projects and their owners",
@@ -58,7 +60,7 @@ func NewProjectListCmd() *cobra.Command {
 		Long: `List projects and their owners.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := config.FromContext(cmd.Context())
-			return project.List(cfg.CatalogDir)
+			return project.List(cfg.CatalogDir, skipCatalogUpdate)
 		},
 	}
 	return cmd

--- a/cmd/joy/project.go
+++ b/cmd/joy/project.go
@@ -40,10 +40,12 @@ This command requires the jac cli: https://github.com/nestoca/jac
 		},
 		Args:               cobra.ArbitraryArgs,
 		DisableFlagParsing: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return checkCatalogUpdateFlag(cmd)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := config.FromContext(cmd.Context())
-			globalFlags := config.FromFlagContext(cmd.Context())
-			return jac.ListProjectPeople(cfg.CatalogDir, args, globalFlags.SkipCatalogUpdate)
+			return jac.ListProjectPeople(cfg.CatalogDir, args)
 		},
 	}
 	return cmd
@@ -57,10 +59,12 @@ func NewProjectListCmd() *cobra.Command {
 			"ls",
 		},
 		Long: `List projects and their owners.`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return checkCatalogUpdateFlag(cmd)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := config.FromContext(cmd.Context())
-			globalFlags := config.FromFlagContext(cmd.Context())
-			return project.List(cfg.CatalogDir, globalFlags.SkipCatalogUpdate)
+			return project.List(cfg.CatalogDir)
 		},
 	}
 	return cmd

--- a/cmd/joy/release.go
+++ b/cmd/joy/release.go
@@ -54,7 +54,7 @@ func NewReleaseListCmd() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List releases across environments",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return checkCatalogUpdateFlag(cmd)
+			return git.EnsureCleanAndUpToDateWorkingCopy(cmd.Context())
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := config.FromContext(cmd.Context())
@@ -118,7 +118,7 @@ func NewReleasePromoteCmd() *cobra.Command {
 				}
 			}
 
-			return checkCatalogUpdateFlag(cmd)
+			return git.EnsureCleanAndUpToDateWorkingCopy(cmd.Context())
 		},
 		RunE: func(cmd *cobra.Command, releases []string) error {
 			cfg := config.FromContext(cmd.Context())
@@ -194,7 +194,7 @@ func NewReleaseSelectCmd() *cobra.Command {
 		Aliases: []string{"sel"},
 		Short:   "Select releases to include in listings and promotions",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return checkCatalogUpdateFlag(cmd)
+			return git.EnsureCleanAndUpToDateWorkingCopy(cmd.Context())
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := config.FromContext(cmd.Context())
@@ -225,7 +225,7 @@ This command requires the jac cli: https://github.com/nestoca/jac
 		Args:               cobra.ArbitraryArgs,
 		DisableFlagParsing: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return checkCatalogUpdateFlag(cmd)
+			return git.EnsureCleanAndUpToDateWorkingCopy(cmd.Context())
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := config.FromContext(cmd.Context())
@@ -467,18 +467,4 @@ func NewGitCommands() *cobra.Command {
 	root.AddCommand(buildCommand("log"))
 
 	return root
-}
-
-func checkCatalogUpdateFlag(cmd *cobra.Command) error {
-	skipCatalogUpdate := config.FlagsFromContext(cmd.Context()).SkipCatalogUpdate
-	cfg := config.FromContext(cmd.Context())
-
-	if skipCatalogUpdate {
-		fmt.Println("ℹ️ Skipping catalog update and dirty check.")
-	} else {
-		if err := git.EnsureCleanAndUpToDateWorkingCopy(cfg.CatalogDir); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/cmd/joy/release.go
+++ b/cmd/joy/release.go
@@ -48,13 +48,14 @@ func NewReleaseCmd() *cobra.Command {
 
 func NewReleaseListCmd() *cobra.Command {
 	var releases, envs, owners string
-	var skipCatalogUpdate bool
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List releases across environments",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := config.FromContext(cmd.Context())
+			globalFlags := config.FromFlagContext(cmd.Context())
+
 			// Filtering
 			var filter filtering.Filter
 			if releases != "" {
@@ -74,7 +75,7 @@ func NewReleaseListCmd() *cobra.Command {
 			}
 
 			return list.List(list.Opts{
-				SkipCatalogUpdate:    skipCatalogUpdate,
+				SkipCatalogUpdate:    globalFlags.SkipCatalogUpdate,
 				CatalogDir:           cfg.CatalogDir,
 				SelectedEnvs:         selectedEnvs,
 				Filter:               filter,
@@ -92,7 +93,7 @@ func NewReleaseListCmd() *cobra.Command {
 
 func NewReleasePromoteCmd() *cobra.Command {
 	var sourceEnv, targetEnv string
-	var autoMerge, draft, dryRun, localOnly, skipCatalogUpdate, noPrompt bool
+	var autoMerge, draft, dryRun, localOnly, noPrompt bool
 
 	cmd := &cobra.Command{
 		Use:     "promote [flags] [releases]",
@@ -118,6 +119,7 @@ func NewReleasePromoteCmd() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, releases []string) error {
 			cfg := config.FromContext(cmd.Context())
+			globalFlags := config.FromFlagContext(cmd.Context())
 
 			var filter filtering.Filter
 			if len(releases) == 0 && len(cfg.Releases.Selected) > 0 {
@@ -156,7 +158,7 @@ func NewReleasePromoteCmd() *cobra.Command {
 				Draft:                draft,
 				DryRun:               dryRun,
 				LocalOnly:            localOnly,
-				SkipCatalogUpdate:    skipCatalogUpdate,
+				SkipCatalogUpdate:    globalFlags.SkipCatalogUpdate,
 				SelectedEnvironments: selectedEnvironments,
 			}
 
@@ -185,7 +187,6 @@ func NewReleasePromoteCmd() *cobra.Command {
 }
 
 func NewReleaseSelectCmd() *cobra.Command {
-	var skipCatalogUpdate bool
 	allFlag := false
 	cmd := &cobra.Command{
 		Use:     "select",
@@ -193,7 +194,8 @@ func NewReleaseSelectCmd() *cobra.Command {
 		Short:   "Select releases to include in listings and promotions",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := config.FromContext(cmd.Context())
-			return release.ConfigureSelection(cfg.CatalogDir, cfg.FilePath, allFlag, skipCatalogUpdate)
+			globalFlags := config.FromFlagContext(cmd.Context())
+			return release.ConfigureSelection(cfg.CatalogDir, cfg.FilePath, allFlag, globalFlags.SkipCatalogUpdate)
 		},
 	}
 	cmd.Flags().BoolVarP(&allFlag, "all", "a", false, "Select all releases (non-interactive)")
@@ -201,7 +203,6 @@ func NewReleaseSelectCmd() *cobra.Command {
 }
 
 func NewReleasePeopleCmd() *cobra.Command {
-	var skipCatalogUpdate bool
 	cmd := &cobra.Command{
 		Use:   "owners",
 		Short: "List people owning a release's project via jac cli",
@@ -222,7 +223,8 @@ This command requires the jac cli: https://github.com/nestoca/jac
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := config.FromContext(cmd.Context())
-			return jac.ListReleasePeople(cfg.CatalogDir, args, skipCatalogUpdate)
+			globalFlags := config.FromFlagContext(cmd.Context())
+			return jac.ListReleasePeople(cfg.CatalogDir, args, globalFlags.SkipCatalogUpdate)
 		},
 	}
 	return cmd

--- a/cmd/joy/release.go
+++ b/cmd/joy/release.go
@@ -47,9 +47,8 @@ func NewReleaseCmd() *cobra.Command {
 }
 
 func NewReleaseListCmd() *cobra.Command {
-	var releases string
-	var envs string
-	var owners string
+	var releases, envs, owners string
+	var skipCatalogUpdate bool
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
@@ -75,6 +74,7 @@ func NewReleaseListCmd() *cobra.Command {
 			}
 
 			return list.List(list.Opts{
+				SkipCatalogUpdate:    skipCatalogUpdate,
 				CatalogDir:           cfg.CatalogDir,
 				SelectedEnvs:         selectedEnvs,
 				Filter:               filter,
@@ -180,12 +180,12 @@ func NewReleasePromoteCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Dry run (do not create PR)")
 	cmd.Flags().BoolVar(&localOnly, "local-only", false, "Similar to dry-run, but updates the release file(s) on the local filesystem only. There is no branch, commits, or PR created.")
 	cmd.Flags().BoolVar(&noPrompt, "no-prompt", false, "Do not prompt user for anything")
-	cmd.Flags().BoolVar(&skipCatalogUpdate, "skip-catalog-update", false, "Skip catalog update and dirty check")
 
 	return cmd
 }
 
 func NewReleaseSelectCmd() *cobra.Command {
+	var skipCatalogUpdate bool
 	allFlag := false
 	cmd := &cobra.Command{
 		Use:     "select",
@@ -193,7 +193,7 @@ func NewReleaseSelectCmd() *cobra.Command {
 		Short:   "Select releases to include in listings and promotions",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := config.FromContext(cmd.Context())
-			return release.ConfigureSelection(cfg.CatalogDir, cfg.FilePath, allFlag)
+			return release.ConfigureSelection(cfg.CatalogDir, cfg.FilePath, allFlag, skipCatalogUpdate)
 		},
 	}
 	cmd.Flags().BoolVarP(&allFlag, "all", "a", false, "Select all releases (non-interactive)")
@@ -201,6 +201,7 @@ func NewReleaseSelectCmd() *cobra.Command {
 }
 
 func NewReleasePeopleCmd() *cobra.Command {
+	var skipCatalogUpdate bool
 	cmd := &cobra.Command{
 		Use:   "owners",
 		Short: "List people owning a release's project via jac cli",
@@ -221,7 +222,7 @@ This command requires the jac cli: https://github.com/nestoca/jac
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := config.FromContext(cmd.Context())
-			return jac.ListReleasePeople(cfg.CatalogDir, args)
+			return jac.ListReleasePeople(cfg.CatalogDir, args, skipCatalogUpdate)
 		},
 	}
 	return cmd

--- a/cmd/joy/release.go
+++ b/cmd/joy/release.go
@@ -117,10 +117,6 @@ func NewReleasePromoteCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, releases []string) error {
-			if skipCatalogUpdate && !(dryRun || localOnly) {
-				return fmt.Errorf("flag --skip-catalog-update requires --dry-run or --local-only")
-			}
-
 			cfg := config.FromContext(cmd.Context())
 
 			var filter filtering.Filter
@@ -184,7 +180,7 @@ func NewReleasePromoteCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Dry run (do not create PR)")
 	cmd.Flags().BoolVar(&localOnly, "local-only", false, "Similar to dry-run, but updates the release file(s) on the local filesystem only. There is no branch, commits, or PR created.")
 	cmd.Flags().BoolVar(&noPrompt, "no-prompt", false, "Do not prompt user for anything")
-	cmd.Flags().BoolVar(&skipCatalogUpdate, "skip-catalog-update", false, "Skip catalog update and dirty check (only in dry run)")
+	cmd.Flags().BoolVar(&skipCatalogUpdate, "skip-catalog-update", false, "Skip catalog update and dirty check")
 
 	return cmd
 }

--- a/cmd/joy/root.go
+++ b/cmd/joy/root.go
@@ -15,12 +15,13 @@ import (
 
 func NewRootCmd(version string) *cobra.Command {
 	var (
-		configDir        string
-		catalogDir       string
-		skipVersionCheck bool
-		setupCmd         = NewSetupCmd(version, &configDir, &catalogDir)
-		diagnoseCmd      = NewDiagnoseCmd(version)
-		versionCmd       = NewVersionCmd(version)
+		configDir         string
+		catalogDir        string
+		skipVersionCheck  bool
+		skipCatalogUpdate bool
+		setupCmd          = NewSetupCmd(version, &configDir, &catalogDir)
+		diagnoseCmd       = NewDiagnoseCmd(version)
+		versionCmd        = NewVersionCmd(version)
 	)
 
 	cmd := &cobra.Command{
@@ -88,6 +89,8 @@ func NewRootCmd(version string) *cobra.Command {
 
 	cmd.PersistentFlags().StringVar(&configDir, "config-dir", "", "Directory containing .joyrc config file (defaults to $HOME)")
 	cmd.PersistentFlags().StringVar(&catalogDir, "catalog-dir", "", "Directory containing joy catalog of environments, projects and releases (defaults to $HOME/.joy)")
+
+	cmd.PersistentFlags().BoolVar(&skipCatalogUpdate, "skip-catalog-update", false, "Skip catalog update and dirty check")
 
 	// Core commands
 	cmd.AddGroup(&cobra.Group{ID: "core", Title: "Core commands"})

--- a/cmd/joy/root.go
+++ b/cmd/joy/root.go
@@ -76,7 +76,7 @@ func NewRootCmd(version string) *cobra.Command {
 				}
 			}
 
-			cmd.SetContext(config.ToFlagContext(cmd.Context(), &flags))
+			cmd.SetContext(config.ToFlagsContext(cmd.Context(), &flags))
 
 			if cmd == setupCmd {
 				return nil

--- a/cmd/joy/root.go
+++ b/cmd/joy/root.go
@@ -15,13 +15,13 @@ import (
 
 func NewRootCmd(version string) *cobra.Command {
 	var (
-		configDir         string
-		catalogDir        string
-		skipVersionCheck  bool
-		skipCatalogUpdate bool
-		setupCmd          = NewSetupCmd(version, &configDir, &catalogDir)
-		diagnoseCmd       = NewDiagnoseCmd(version)
-		versionCmd        = NewVersionCmd(version)
+		configDir        string
+		catalogDir       string
+		skipVersionCheck bool
+		flags            config.GlobalFlags
+		setupCmd         = NewSetupCmd(version, &configDir, &catalogDir)
+		diagnoseCmd      = NewDiagnoseCmd(version)
+		versionCmd       = NewVersionCmd(version)
 	)
 
 	cmd := &cobra.Command{
@@ -76,6 +76,8 @@ func NewRootCmd(version string) *cobra.Command {
 				}
 			}
 
+			cmd.SetContext(config.ToFlagContext(cmd.Context(), &flags))
+
 			if cmd == setupCmd {
 				return nil
 			}
@@ -90,7 +92,7 @@ func NewRootCmd(version string) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&configDir, "config-dir", "", "Directory containing .joyrc config file (defaults to $HOME)")
 	cmd.PersistentFlags().StringVar(&catalogDir, "catalog-dir", "", "Directory containing joy catalog of environments, projects and releases (defaults to $HOME/.joy)")
 
-	cmd.PersistentFlags().BoolVar(&skipCatalogUpdate, "skip-catalog-update", false, "Skip catalog update and dirty check")
+	cmd.PersistentFlags().BoolVar(&flags.SkipCatalogUpdate, "skip-catalog-update", false, "Skip catalog update and dirty check")
 
 	// Core commands
 	cmd.AddGroup(&cobra.Group{ID: "core", Title: "Core commands"})

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -9,11 +9,11 @@ type GlobalFlags struct {
 
 type flagKey struct{}
 
-func ToFlagContext(parent context.Context, flags *GlobalFlags) context.Context {
+func ToFlagsContext(parent context.Context, flags *GlobalFlags) context.Context {
 	return context.WithValue(parent, flagKey{}, flags)
 }
 
-func FromFlagContext(ctx context.Context) *GlobalFlags {
+func FlagsFromContext(ctx context.Context) *GlobalFlags {
 	cfg, _ := ctx.Value(flagKey{}).(*GlobalFlags)
 	return cfg
 }

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -1,0 +1,19 @@
+package config
+
+import "context"
+
+type GlobalFlags struct {
+	// SkipCatalogUpdate global flag used to skip catalog update and dirty check.
+	SkipCatalogUpdate bool
+}
+
+type flagKey struct{}
+
+func ToFlagContext(parent context.Context, flags *GlobalFlags) context.Context {
+	return context.WithValue(parent, flagKey{}, flags)
+}
+
+func FromFlagContext(ctx context.Context) *GlobalFlags {
+	cfg, _ := ctx.Value(flagKey{}).(*GlobalFlags)
+	return cfg
+}

--- a/internal/environment/configure_selection.go
+++ b/internal/environment/configure_selection.go
@@ -10,10 +10,13 @@ import (
 	"github.com/nestoca/joy/pkg/catalog"
 )
 
-func ConfigureSelection(catalogDir, configFilePath string, all bool) error {
-	err := git.EnsureCleanAndUpToDateWorkingCopy(catalogDir)
-	if err != nil {
-		return err
+func ConfigureSelection(catalogDir, configFilePath string, all, skipCatalogUpdate bool) error {
+	if skipCatalogUpdate {
+		fmt.Println("ℹ️ Skipping catalog update and dirty check.")
+	} else {
+		if err := git.EnsureCleanAndUpToDateWorkingCopy(catalogDir); err != nil {
+			return err
+		}
 	}
 
 	// Load fresh copy of config file, without any alterations/defaults applied

--- a/internal/environment/configure_selection.go
+++ b/internal/environment/configure_selection.go
@@ -6,19 +6,10 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 
 	"github.com/nestoca/joy/internal/config"
-	"github.com/nestoca/joy/internal/git"
 	"github.com/nestoca/joy/pkg/catalog"
 )
 
-func ConfigureSelection(catalogDir, configFilePath string, all, skipCatalogUpdate bool) error {
-	if skipCatalogUpdate {
-		fmt.Println("ℹ️ Skipping catalog update and dirty check.")
-	} else {
-		if err := git.EnsureCleanAndUpToDateWorkingCopy(catalogDir); err != nil {
-			return err
-		}
-	}
-
+func ConfigureSelection(catalogDir, configFilePath string, all bool) error {
 	// Load fresh copy of config file, without any alterations/defaults applied
 	cfg, err := config.LoadFile(configFilePath)
 	if err != nil {

--- a/internal/git/clean_working_copy.go
+++ b/internal/git/clean_working_copy.go
@@ -18,6 +18,19 @@ func EnsureCleanAndUpToDateWorkingCopy(dir string) error {
 		return fmt.Errorf("uncommitted changes detected:\n%s", style.Warning(strings.Join(changes, "\n")))
 	}
 
+	defaultBranch, err := GetDefaultBranch(dir)
+	if err != nil {
+		return fmt.Errorf("getting default branch: %w", err)
+	}
+	err = Checkout(dir, defaultBranch)
+	if err != nil {
+		return fmt.Errorf("checking out default branch: %w", err)
+	}
+	err = Pull(dir)
+	if err != nil {
+		return fmt.Errorf("pulling changes: %w", err)
+	}
+
 	buf := bytes.Buffer{}
 	cmd := exec.Command("git", "-C", dir, "pull")
 	cmd.Stdout = &buf

--- a/internal/git/clean_working_copy.go
+++ b/internal/git/clean_working_copy.go
@@ -24,6 +24,7 @@ func EnsureCleanAndUpToDateWorkingCopy(dir string) error {
 	if err != nil {
 		return fmt.Errorf("checking out default branch: %w", err)
 	}
+	fmt.Printf("ℹ️ Catalog: checking out %s branch\n", defaultBranch)
 	err = Pull(dir)
 	if err != nil {
 		return fmt.Errorf("pulling changes: %w", err)

--- a/internal/git/clean_working_copy.go
+++ b/internal/git/clean_working_copy.go
@@ -1,9 +1,7 @@
 package git
 
 import (
-	"bytes"
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"github.com/nestoca/joy/internal/style"
@@ -31,13 +29,5 @@ func EnsureCleanAndUpToDateWorkingCopy(dir string) error {
 		return fmt.Errorf("pulling changes: %w", err)
 	}
 
-	buf := bytes.Buffer{}
-	cmd := exec.Command("git", "-C", dir, "pull")
-	cmd.Stdout = &buf
-	cmd.Stderr = &buf
-	err = cmd.Run()
-	if err != nil {
-		return fmt.Errorf("pulling changes:\n%s", buf.String())
-	}
 	return nil
 }

--- a/internal/git/clean_working_copy.go
+++ b/internal/git/clean_working_copy.go
@@ -1,13 +1,23 @@
 package git
 
 import (
+	"context"
 	"fmt"
+	"github.com/nestoca/joy/internal/config"
 	"strings"
 
 	"github.com/nestoca/joy/internal/style"
 )
 
-func EnsureCleanAndUpToDateWorkingCopy(dir string) error {
+func EnsureCleanAndUpToDateWorkingCopy(ctx context.Context) error {
+
+	if config.FlagsFromContext(ctx).SkipCatalogUpdate {
+		fmt.Println("ℹ️ Skipping catalog update and dirty check.")
+		return nil
+	}
+
+	dir := config.FromContext(ctx).CatalogDir
+
 	changes, err := GetUncommittedChanges(dir)
 	if err != nil {
 		return fmt.Errorf("getting uncommitted changes: %w", err)
@@ -20,13 +30,13 @@ func EnsureCleanAndUpToDateWorkingCopy(dir string) error {
 	if err != nil {
 		return fmt.Errorf("getting default branch: %w", err)
 	}
-	err = Checkout(dir, defaultBranch)
-	if err != nil {
+
+	if err = Checkout(dir, defaultBranch); err != nil {
 		return fmt.Errorf("checking out default branch: %w", err)
 	}
 	fmt.Printf("ℹ️ Catalog: checking out %s branch\n", defaultBranch)
-	err = Pull(dir)
-	if err != nil {
+
+	if err = Pull(dir); err != nil {
 		return fmt.Errorf("pulling changes: %w", err)
 	}
 

--- a/internal/jac/jac.go
+++ b/internal/jac/jac.go
@@ -27,14 +27,17 @@ func init() {
 	dependencies.Add(dependency)
 }
 
-func ListProjectPeople(catalogDir string, extraArgs []string) error {
+func ListProjectPeople(catalogDir string, extraArgs []string, skipCatalogUpdate bool) error {
 	if err := dependency.MustBeInstalled(); err != nil {
 		return err
 	}
 
-	err := git.EnsureCleanAndUpToDateWorkingCopy(catalogDir)
-	if err != nil {
-		return err
+	if skipCatalogUpdate {
+		fmt.Println("ℹ️ Skipping catalog update and dirty check.")
+	} else {
+		if err := git.EnsureCleanAndUpToDateWorkingCopy(catalogDir); err != nil {
+			return err
+		}
 	}
 
 	cat, err := catalog.Load(catalog.LoadOpts{Dir: catalogDir})
@@ -51,14 +54,17 @@ func ListProjectPeople(catalogDir string, extraArgs []string) error {
 	return listPeopleWithGroups(selectedProject.Spec.Owners, extraArgs)
 }
 
-func ListReleasePeople(catalogDir string, extraArgs []string) error {
+func ListReleasePeople(catalogDir string, extraArgs []string, skipCatalogUpdate bool) error {
 	if err := dependency.MustBeInstalled(); err != nil {
 		return err
 	}
 
-	err := git.EnsureCleanAndUpToDateWorkingCopy(catalogDir)
-	if err != nil {
-		return err
+	if skipCatalogUpdate {
+		fmt.Println("ℹ️ Skipping catalog update and dirty check.")
+	} else {
+		if err := git.EnsureCleanAndUpToDateWorkingCopy(catalogDir); err != nil {
+			return err
+		}
 	}
 
 	cat, err := catalog.Load(catalog.LoadOpts{Dir: catalogDir})

--- a/internal/jac/jac.go
+++ b/internal/jac/jac.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/nestoca/joy/api/v1alpha1"
 	"github.com/nestoca/joy/internal/dependencies"
-	"github.com/nestoca/joy/internal/git"
 	"github.com/nestoca/joy/internal/release/cross"
 	"github.com/nestoca/joy/internal/style"
 	"github.com/nestoca/joy/pkg/catalog"
@@ -27,17 +26,9 @@ func init() {
 	dependencies.Add(dependency)
 }
 
-func ListProjectPeople(catalogDir string, extraArgs []string, skipCatalogUpdate bool) error {
+func ListProjectPeople(catalogDir string, extraArgs []string) error {
 	if err := dependency.MustBeInstalled(); err != nil {
 		return err
-	}
-
-	if skipCatalogUpdate {
-		fmt.Println("ℹ️ Skipping catalog update and dirty check.")
-	} else {
-		if err := git.EnsureCleanAndUpToDateWorkingCopy(catalogDir); err != nil {
-			return err
-		}
 	}
 
 	cat, err := catalog.Load(catalog.LoadOpts{Dir: catalogDir})
@@ -54,17 +45,9 @@ func ListProjectPeople(catalogDir string, extraArgs []string, skipCatalogUpdate 
 	return listPeopleWithGroups(selectedProject.Spec.Owners, extraArgs)
 }
 
-func ListReleasePeople(catalogDir string, extraArgs []string, skipCatalogUpdate bool) error {
+func ListReleasePeople(catalogDir string, extraArgs []string) error {
 	if err := dependency.MustBeInstalled(); err != nil {
 		return err
-	}
-
-	if skipCatalogUpdate {
-		fmt.Println("ℹ️ Skipping catalog update and dirty check.")
-	} else {
-		if err := git.EnsureCleanAndUpToDateWorkingCopy(catalogDir); err != nil {
-			return err
-		}
 	}
 
 	cat, err := catalog.Load(catalog.LoadOpts{Dir: catalogDir})

--- a/internal/project/list.go
+++ b/internal/project/list.go
@@ -2,19 +2,22 @@ package project
 
 import (
 	"fmt"
+	"github.com/nestoca/joy/internal/git"
 	"os"
 	"strings"
 
 	"github.com/olekukonko/tablewriter"
 
-	"github.com/nestoca/joy/internal/git"
 	"github.com/nestoca/joy/pkg/catalog"
 )
 
-func List(catalogDir string) error {
-	err := git.EnsureCleanAndUpToDateWorkingCopy(catalogDir)
-	if err != nil {
-		return err
+func List(catalogDir string, skipCatalogUpdate bool) error {
+	if skipCatalogUpdate {
+		fmt.Println("ℹ️ Skipping catalog update and dirty check.")
+	} else {
+		if err := git.EnsureCleanAndUpToDateWorkingCopy(catalogDir); err != nil {
+			return err
+		}
 	}
 
 	cat, err := catalog.Load(catalog.LoadOpts{Dir: catalogDir})

--- a/internal/project/list.go
+++ b/internal/project/list.go
@@ -2,7 +2,6 @@ package project
 
 import (
 	"fmt"
-	"github.com/nestoca/joy/internal/git"
 	"os"
 	"strings"
 
@@ -11,15 +10,7 @@ import (
 	"github.com/nestoca/joy/pkg/catalog"
 )
 
-func List(catalogDir string, skipCatalogUpdate bool) error {
-	if skipCatalogUpdate {
-		fmt.Println("ℹ️ Skipping catalog update and dirty check.")
-	} else {
-		if err := git.EnsureCleanAndUpToDateWorkingCopy(catalogDir); err != nil {
-			return err
-		}
-	}
-
+func List(catalogDir string) error {
 	cat, err := catalog.Load(catalog.LoadOpts{Dir: catalogDir})
 	if err != nil {
 		return fmt.Errorf("loading catalog: %w", err)

--- a/internal/release/configure_selection.go
+++ b/internal/release/configure_selection.go
@@ -11,10 +11,13 @@ import (
 	"github.com/nestoca/joy/pkg/catalog"
 )
 
-func ConfigureSelection(catalogDir, configFilePath string, all bool) error {
-	err := git.EnsureCleanAndUpToDateWorkingCopy(catalogDir)
-	if err != nil {
-		return err
+func ConfigureSelection(catalogDir, configFilePath string, all, skipCatalogUpdate bool) error {
+	if skipCatalogUpdate {
+		fmt.Println("ℹ️ Skipping catalog update and dirty check.")
+	} else {
+		if err := git.EnsureCleanAndUpToDateWorkingCopy(catalogDir); err != nil {
+			return err
+		}
 	}
 
 	// Load fresh copy of config file, without any alterations/defaults applied

--- a/internal/release/configure_selection.go
+++ b/internal/release/configure_selection.go
@@ -7,18 +7,10 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 
 	"github.com/nestoca/joy/internal/config"
-	"github.com/nestoca/joy/internal/git"
 	"github.com/nestoca/joy/pkg/catalog"
 )
 
-func ConfigureSelection(catalogDir, configFilePath string, all, skipCatalogUpdate bool) error {
-	if skipCatalogUpdate {
-		fmt.Println("ℹ️ Skipping catalog update and dirty check.")
-	} else {
-		if err := git.EnsureCleanAndUpToDateWorkingCopy(catalogDir); err != nil {
-			return err
-		}
-	}
+func ConfigureSelection(catalogDir, configFilePath string, all bool) error {
 
 	// Load fresh copy of config file, without any alterations/defaults applied
 	cfg, err := config.LoadFile(configFilePath)

--- a/internal/release/list/list.go
+++ b/internal/release/list/list.go
@@ -2,6 +2,7 @@ package list
 
 import (
 	"fmt"
+	"github.com/nestoca/joy/internal/git"
 	"io"
 	"os"
 	"slices"
@@ -13,7 +14,6 @@ import (
 
 	"github.com/jedib0t/go-pretty/v6/table"
 
-	"github.com/nestoca/joy/internal/git"
 	"github.com/nestoca/joy/internal/release/filtering"
 	"github.com/nestoca/joy/internal/style"
 	"github.com/nestoca/joy/pkg/catalog"
@@ -31,11 +31,19 @@ type Opts struct {
 	Filter filtering.Filter
 
 	ReferenceEnvironment string
+
+	// SkipCatalogUpdate skips catalog update and dirty check. Very useful for
+	// troubleshooting and testing templates.
+	SkipCatalogUpdate bool
 }
 
 func List(opts Opts) error {
-	if err := git.EnsureCleanAndUpToDateWorkingCopy(opts.CatalogDir); err != nil {
-		return err
+	if opts.SkipCatalogUpdate {
+		fmt.Println("ℹ️ Skipping catalog update and dirty check.")
+	} else {
+		if err := git.EnsureCleanAndUpToDateWorkingCopy(opts.CatalogDir); err != nil {
+			return err
+		}
 	}
 
 	cat, err := catalog.Load(catalog.LoadOpts{

--- a/internal/release/list/list.go
+++ b/internal/release/list/list.go
@@ -2,7 +2,6 @@ package list
 
 import (
 	"fmt"
-	"github.com/nestoca/joy/internal/git"
 	"io"
 	"os"
 	"slices"
@@ -31,21 +30,9 @@ type Opts struct {
 	Filter filtering.Filter
 
 	ReferenceEnvironment string
-
-	// SkipCatalogUpdate skips catalog update and dirty check. Very useful for
-	// troubleshooting and testing templates.
-	SkipCatalogUpdate bool
 }
 
 func List(opts Opts) error {
-	if opts.SkipCatalogUpdate {
-		fmt.Println("ℹ️ Skipping catalog update and dirty check.")
-	} else {
-		if err := git.EnsureCleanAndUpToDateWorkingCopy(opts.CatalogDir); err != nil {
-			return err
-		}
-	}
-
 	cat, err := catalog.Load(catalog.LoadOpts{
 		Dir:             opts.CatalogDir,
 		ReleaseFilter:   opts.Filter,

--- a/internal/release/promote/git_provider.go
+++ b/internal/release/promote/git_provider.go
@@ -2,7 +2,6 @@
 package promote
 
 type GitProvider interface {
-	EnsureCleanAndUpToDateWorkingCopy() error
 	CreateAndPushBranchWithFiles(branchName string, files []string, message string) error
 	CheckoutMasterBranch() error
 }

--- a/internal/release/promote/promotion.go
+++ b/internal/release/promote/promotion.go
@@ -108,10 +108,6 @@ type Opts struct {
 
 	// LocalOnly indicates if the promotion should only write the promotion changes to the working tree without creating a branch, commit or pull request.
 	LocalOnly bool
-
-	// SkipCatalogUpdate skips catalog update and dirty check. Very useful for
-	// troubleshooting and testing templates.
-	SkipCatalogUpdate bool
 }
 
 // Promote prompts user to select source and target environments and releases to promote and creates a pull request,
@@ -123,14 +119,6 @@ func (p *Promotion) Promote(opts Opts) (string, error) {
 
 	if opts.LocalOnly {
 		fmt.Println("ℹ️ Local-only mode enabled: The local repo will be modified, but not committed. No pull request will be created.")
-	}
-
-	if opts.SkipCatalogUpdate {
-		fmt.Println("ℹ️ Skipping catalog update and dirty check.")
-	} else {
-		if err := p.gitProvider.EnsureCleanAndUpToDateWorkingCopy(); err != nil {
-			return "", err
-		}
 	}
 
 	// Prompt user to select source environment

--- a/internal/release/promote/promotion.go
+++ b/internal/release/promote/promotion.go
@@ -109,8 +109,8 @@ type Opts struct {
 	// LocalOnly indicates if the promotion should only write the promotion changes to the working tree without creating a branch, commit or pull request.
 	LocalOnly bool
 
-	// SkipCatalogUpdate skips catalog update and dirty check in dry-run mode.  Very useful
-	// for troubleshooting and testing templates.
+	// SkipCatalogUpdate skips catalog update and dirty check. Very useful for
+	// troubleshooting and testing templates.
 	SkipCatalogUpdate bool
 }
 

--- a/internal/release/promote/shell_git_provider.go
+++ b/internal/release/promote/shell_git_provider.go
@@ -14,10 +14,6 @@ func NewShellGitProvider(dir string) *ShellGitProvider {
 	return &ShellGitProvider{dir: dir}
 }
 
-func (g *ShellGitProvider) EnsureCleanAndUpToDateWorkingCopy() error {
-	return git.EnsureCleanAndUpToDateWorkingCopy(g.dir)
-}
-
 func (g *ShellGitProvider) CreateAndPushBranchWithFiles(branchName string, files []string, message string) error {
 	err := git.CreateBranch(g.dir, branchName)
 	if err != nil {

--- a/internal/release/promote/test/promotion_test.go
+++ b/internal/release/promote/test/promotion_test.go
@@ -88,7 +88,6 @@ func TestPromotion(t *testing.T) {
 				opts := args.opts
 				opts.SourceEnv = opts.Catalog.Environments[devEnvIndex]
 				opts.TargetEnv = opts.Catalog.Environments[stagingEnvIndex]
-				args.gitProvider.EXPECT().EnsureCleanAndUpToDateWorkingCopy().Return(nil)
 			},
 			expectedErrorMessage: "environment dev is not promotable to staging",
 			expectedPromoted:     false,
@@ -98,7 +97,6 @@ func TestPromotion(t *testing.T) {
 			opts: newOpts(),
 			setup: func(args setupArgs) {
 				opts := args.opts
-				args.gitProvider.EXPECT().EnsureCleanAndUpToDateWorkingCopy().Return(nil)
 				args.promptProvider.EXPECT().PrintNoPromotableReleasesFound(opts.ReleasesFiltered, opts.SourceEnv, opts.TargetEnv)
 			},
 			expectedPromoted: false,
@@ -114,7 +112,6 @@ func TestPromotion(t *testing.T) {
 				opts.Catalog.Releases.Items[0].Releases[targetEnvIndex] = newRelease("release1", `spec:
   values:
     key: !lock value2`, targetEnvName)
-				args.gitProvider.EXPECT().EnsureCleanAndUpToDateWorkingCopy().Return(nil)
 				args.promptProvider.EXPECT().PrintNoPromotableReleasesFound(opts.ReleasesFiltered, opts.SourceEnv, opts.TargetEnv)
 			},
 			expectedPromoted: false,
@@ -146,7 +143,6 @@ func TestPromotion(t *testing.T) {
 				crossRel0.Releases[sourceEnvIndex] = sourceRelease
 				crossRel0.Releases[targetEnvIndex] = targetRelease
 
-				args.gitProvider.EXPECT().EnsureCleanAndUpToDateWorkingCopy().Return(nil)
 				args.promptProvider.EXPECT().SelectReleases(gomock.Any()).DoAndReturn(func(list *cross.ReleaseList) (*cross.ReleaseList, error) { return list, nil })
 				args.promptProvider.EXPECT().PrintStartPreview()
 				args.promptProvider.EXPECT().PrintReleasePreview(targetEnv.Name, crossRel0.Name, targetRelease.File, expectedPromotedFile)
@@ -203,7 +199,6 @@ func TestPromotion(t *testing.T) {
 
 				expectedPromotedFile.Path = fmt.Sprintf("%s/releases/testing/test.yaml", targetEnv.Dir)
 
-				args.gitProvider.EXPECT().EnsureCleanAndUpToDateWorkingCopy().Return(nil)
 				args.promptProvider.EXPECT().SelectReleases(gomock.Any()).DoAndReturn(func(list *cross.ReleaseList) (*cross.ReleaseList, error) { return list, nil })
 				args.promptProvider.EXPECT().PrintStartPreview()
 				args.promptProvider.EXPECT().PrintReleasePreview(targetEnv.Name, crossRel0.Name, nil, expectedPromotedFile)


### PR DESCRIPTION
ensures the catalog is at origin head
Changing skip-catalog-update to a global flag 
Moving the check of skipCatalogUpdate to PreRun of the command instead of the specific actions