### PR TITLE
feat(PL-2460): add `--local-only` mode

### DIFF
--- a/cmd/joy/release.go
+++ b/cmd/joy/release.go
@@ -90,7 +90,7 @@ func NewReleaseListCmd() *cobra.Command {
 
 func NewReleasePromoteCmd() *cobra.Command {
 	var sourceEnv, targetEnv string
-	var autoMerge, draft, dryRun, skipCatalogUpdate, noPrompt bool
+	var autoMerge, draft, dryRun, localOnly, skipCatalogUpdate, noPrompt bool
 
 	cmd := &cobra.Command{
 		Use:     "promote [flags] [releases]",
@@ -115,8 +115,8 @@ func NewReleasePromoteCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, releases []string) error {
-			if skipCatalogUpdate && !dryRun {
-				return fmt.Errorf("flag --skip-catalog-update requires --dry-run")
+			if skipCatalogUpdate && !(dryRun || localOnly) {
+				return fmt.Errorf("flag --skip-catalog-update requires --dry-run or --local-only")
 			}
 
 			cfg := config.FromContext(cmd.Context())
@@ -157,6 +157,7 @@ func NewReleasePromoteCmd() *cobra.Command {
 				AutoMerge:            autoMerge,
 				Draft:                draft,
 				DryRun:               dryRun,
+				LocalOnly:            localOnly,
 				SkipCatalogUpdate:    skipCatalogUpdate,
 				SelectedEnvironments: selectedEnvironments,
 			}
@@ -179,6 +180,7 @@ func NewReleasePromoteCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&autoMerge, "auto-merge", false, "Add auto-merge label to release PR")
 	cmd.Flags().BoolVar(&draft, "draft", false, "Create draft release PR")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Dry run (do not create PR)")
+	cmd.Flags().BoolVar(&localOnly, "local-only", false, "Similar to dry-run, but updates the release file(s) on the local filesystem only. There is no branch, commits, or PR created.")
 	cmd.Flags().BoolVar(&noPrompt, "no-prompt", false, "Do not prompt user for anything")
 	cmd.Flags().BoolVar(&skipCatalogUpdate, "skip-catalog-update", false, "Skip catalog update and dirty check (only in dry run)")
 

--- a/internal/release/promote/promotion.go
+++ b/internal/release/promote/promotion.go
@@ -106,6 +106,9 @@ type Opts struct {
 	// DryRun indicates if the promotion should be performed in dry-run mode
 	DryRun bool
 
+	// LocalOnly indicates if the promotion should only write the promotion changes to the working tree without creating a branch, commit or pull request.
+	LocalOnly bool
+
 	// SkipCatalogUpdate skips catalog update and dirty check in dry-run mode.  Very useful
 	// for troubleshooting and testing templates.
 	SkipCatalogUpdate bool
@@ -116,6 +119,10 @@ type Opts struct {
 func (p *Promotion) Promote(opts Opts) (string, error) {
 	if opts.DryRun {
 		fmt.Println("ℹ️ Dry-run mode enabled: No changes will be made.")
+	}
+
+	if opts.LocalOnly {
+		fmt.Println("ℹ️ Local-only mode enabled: The local repo will be modified, but not committed. No pull request will be created.")
 	}
 
 	if opts.SkipCatalogUpdate {
@@ -198,6 +205,7 @@ func (p *Promotion) Promote(opts Opts) (string, error) {
 		autoMerge:                   opts.AutoMerge,
 		draft:                       opts.Draft,
 		dryRun:                      opts.DryRun,
+		localOnly:                   opts.LocalOnly,
 		commitTemplate:              p.commitTemplate,
 		pullRequestTemplate:         p.pullRequestTemplate,
 		getProjectSourceDirFunc:     p.getProjectSourceDirFunc,


### PR DESCRIPTION
A better name is more than welcome. This is similar to a `--dry-run` (preview, no PR, etc.), but it writes the changes to the local filesystem.

We joked around calling it `--moist-run`. I need this change for my bulk `!lock`ing. So there it is.