### PR TITLE
fix(PL-2477): fix nil deref bug in joy perform

### DIFF
--- a/internal/release/promote/perform.go
+++ b/internal/release/promote/perform.go
@@ -209,9 +209,15 @@ func getReviewers(info *PromotionInfo) []string {
 		for _, owner := range release.CodeOwners {
 			uniqueAuthors[owner] = true
 		}
-		for _, owner := range release.Project.Spec.CodeOwners {
-			uniqueAuthors[owner] = true
+
+		// releaseInfo.Project may be nil if an error was encountered.
+		// therefore we need to check if the project exists before dereferencing it
+		if release.Project != nil {
+			for _, owner := range release.Project.Spec.CodeOwners {
+				uniqueAuthors[owner] = true
+			}
 		}
+
 		for _, commit := range release.Commits {
 			uniqueAuthors[commit.GitHubAuthor] = true
 		}

--- a/internal/release/promote/perform_test.go
+++ b/internal/release/promote/perform_test.go
@@ -1,6 +1,7 @@
 package promote
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -148,4 +149,17 @@ func TestRenderMessage(t *testing.T) {
 	message, err := renderMessage(messageTemplate, info)
 	require.NoError(t, err)
 	require.Equal(t, expectedMessage, message)
+}
+
+func TestGetReviewers(t *testing.T) {
+	require.Equal(
+		t,
+		[]string{"john"},
+		getReviewers(&PromotionInfo{
+			Releases: []*ReleaseInfo{
+				{CodeOwners: []string{"john"}},
+				{Error: errors.New("error")},
+			},
+		}),
+	)
 }


### PR DESCRIPTION
Fix bug where releaseInfo that did not have Project would have its project derefenced