### PR TITLE
feat(PL-2418): add !local tag annotation

### DIFF
--- a/internal/yml/tags.go
+++ b/internal/yml/tags.go
@@ -11,6 +11,6 @@ var StandardTags = []string{
 	"!!null",
 }
 
-var CustomTags = []string{"!lock"}
+var CustomTags = []string{"!lock", "!local"}
 
 var KnownTags = append(StandardTags, CustomTags...)


### PR DESCRIPTION
This PR adds `!local` annotations for values that should be locked, but should not have their structure promoted across environment boundaries.