### PR TITLE
fix(PL-2574): should not save selection to catalog config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -202,6 +202,9 @@ func deepCopyNonZeroValues(src, tgt reflect.Value) {
 				}
 			}
 		default:
+			if src.Type().Field(i).Tag.Get("yaml") == "-" {
+				continue
+			}
 			if !isZeroValue(srcField.Interface()) {
 				tgtField.Set(srcField)
 			}


### PR DESCRIPTION
This fix skips non-yaml-persisted fields when merging catalog configs using reflection, so that user settings don't get saved back to catalog config. This is an OK fix for now, but we'll soon refactor all that to properly isolate catalog configs from user preferences.