### PR TITLE
feat(PL-2575)/narrow-wide-column-modes

### DIFF
--- a/cmd/joy/release.go
+++ b/cmd/joy/release.go
@@ -58,6 +58,7 @@ func NewReleaseCmd() *cobra.Command {
 
 func NewReleaseListCmd() *cobra.Command {
 	var releases, envs, owners string
+	var narrow, wide bool
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
@@ -91,20 +92,24 @@ func NewReleaseListCmd() *cobra.Command {
 				SelectedEnvs:         selectedEnvs,
 				Filter:               filter,
 				ReferenceEnvironment: cfg.ReferenceEnvironment,
+				MaxColumnWidth:       cfg.ColumnWidths.Get(narrow, wide),
 			})
 		},
 	}
 	cmd.Flags().StringVarP(&releases, "releases", "r", "", "Releases to list (comma-separated with wildcards, defaults to configured selection or all)")
 	cmd.Flags().StringVarP(&envs, "env", "e", "", "environments to list (comma-separated, defaults to configured selection or all)")
 	cmd.Flags().StringVarP(&owners, "owners", "o", "", "List releases by owners (comma-separated, defaults to all)")
+	cmd.Flags().BoolVarP(&narrow, "narrow", "n", false, "Use narrow columns mode")
+	cmd.Flags().BoolVarP(&wide, "wide", "w", false, "Use wide columns mode")
 	cmd.MarkFlagsMutuallyExclusive("releases", "owners")
+	cmd.MarkFlagsMutuallyExclusive("narrow", "wide")
 
 	return cmd
 }
 
 func NewReleasePromoteCmd() *cobra.Command {
 	var sourceEnv, targetEnv string
-	var autoMerge, draft, dryRun, localOnly, noPrompt bool
+	var autoMerge, draft, dryRun, localOnly, noPrompt, narrow, wide bool
 
 	cmd := &cobra.Command{
 		Use:     "promote [flags] [releases]",
@@ -170,6 +175,7 @@ func NewReleasePromoteCmd() *cobra.Command {
 				DryRun:               dryRun,
 				LocalOnly:            localOnly,
 				SelectedEnvironments: selectedEnvironments,
+				MaxColumnWidth:       cfg.ColumnWidths.Get(narrow, wide),
 			}
 
 			infoProvider := info.NewProvider(cfg.GitHubOrganization, cfg.Templates.Project.GitTag, cfg.RepositoriesDir, cfg.JoyCache)
@@ -194,6 +200,9 @@ func NewReleasePromoteCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Dry run (do not create PR)")
 	cmd.Flags().BoolVar(&localOnly, "local-only", false, "Similar to dry-run, but updates the release file(s) on the local filesystem only. There is no branch, commits, or PR created.")
 	cmd.Flags().BoolVar(&noPrompt, "no-prompt", false, "Do not prompt user for anything")
+	cmd.Flags().BoolVarP(&narrow, "narrow", "n", false, "Use narrow columns mode")
+	cmd.Flags().BoolVarP(&wide, "wide", "w", false, "Use wide columns mode")
+	cmd.MarkFlagsMutuallyExclusive("narrow", "wide")
 
 	return cmd
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -61,6 +62,30 @@ type Config struct {
 	GitHubOrganization string `yaml:"gitHubOrganization,omitempty"`
 
 	Templates Templates `yaml:"templates,omitempty"`
+
+	ColumnWidths ColumnWidths `yaml:"columnWidths,omitempty"`
+}
+
+const (
+	DefaultNarrowColumnWidth = 20
+	DefaultNormalColumnWidth = 40
+	DefaultWideColumnWidth   = 80
+)
+
+type ColumnWidths struct {
+	Narrow int `yaml:"narrow,omitempty"`
+	Normal int `yaml:"normal,omitempty"`
+	Wide   int `yaml:"wide,omitempty"`
+}
+
+func (c ColumnWidths) Get(narrow, wide bool) int {
+	if narrow {
+		return cmp.Or(c.Narrow, DefaultNarrowColumnWidth)
+	}
+	if wide {
+		return cmp.Or(c.Wide, DefaultWideColumnWidth)
+	}
+	return cmp.Or(c.Normal, DefaultNormalColumnWidth)
 }
 
 type Templates struct {

--- a/internal/release/list/list.go
+++ b/internal/release/list/list.go
@@ -2,8 +2,6 @@ package list
 
 import (
 	"fmt"
-	"io"
-	"os"
 	"slices"
 	"strings"
 
@@ -30,6 +28,8 @@ type Opts struct {
 	Filter filtering.Filter
 
 	ReferenceEnvironment string
+
+	MaxColumnWidth int
 }
 
 func List(opts Opts) error {
@@ -77,7 +77,7 @@ func List(opts Opts) error {
 			style.InSyncVersion("in-sync"),
 		})
 
-		io.WriteString(os.Stdout, legend.Render()+"\n")
+		fmt.Println(legend.Render())
 	}
 
 	for _, crossRelease := range cat.Releases.Items {
@@ -91,6 +91,9 @@ func List(opts Opts) error {
 			}
 			if slices.Contains(disallowEnvIndexes, i) {
 				continue
+			}
+			if opts.MaxColumnWidth != 0 && len(displayVersion) > opts.MaxColumnWidth {
+				displayVersion = displayVersion[:opts.MaxColumnWidth-3] + "..."
 			}
 			row = append(row, displayVersion)
 		}
@@ -128,7 +131,7 @@ func List(opts Opts) error {
 		t.AppendRow(row)
 	}
 
-	io.WriteString(os.Stdout, t.Render()+"\n")
+	fmt.Println(t.Render())
 
 	return nil
 }

--- a/internal/release/promote/promotion.go
+++ b/internal/release/promote/promotion.go
@@ -59,6 +59,8 @@ type Opts struct {
 
 	// LocalOnly indicates if the promotion should only write the promotion changes to the working tree without creating a branch, commit or pull request.
 	LocalOnly bool
+
+	MaxColumnWidth int
 }
 
 // Promote prompts user to select source and target environments and releases to promote and creates a pull request,
@@ -119,7 +121,7 @@ func (p *Promotion) Promote(opts Opts) (string, error) {
 		if len(opts.Releases) > 0 {
 			return list.OnlySpecificReleases(opts.Releases), nil
 		}
-		return p.PromptProvider.SelectReleases(list)
+		return p.PromptProvider.SelectReleases(list, opts.MaxColumnWidth)
 	}()
 	if err != nil {
 		return "", fmt.Errorf("selecting releases to promote: %w", err)

--- a/internal/release/promote/prompt_provider.go
+++ b/internal/release/promote/prompt_provider.go
@@ -15,7 +15,7 @@ type PromptProvider interface {
 	SelectTargetEnvironment(environments []*v1alpha1.Environment) (*v1alpha1.Environment, error)
 
 	// SelectReleases prompts user to select releases to promote.
-	SelectReleases(list *cross.ReleaseList) (*cross.ReleaseList, error)
+	SelectReleases(list *cross.ReleaseList, maxColumnWidth int) (*cross.ReleaseList, error)
 
 	// ConfirmCreatingPromotionPullRequest prompts user to confirm whether to continue creating promotion pull request
 	// or abort.

--- a/internal/release/promote/test/integration_test.go
+++ b/internal/release/promote/test/integration_test.go
@@ -49,7 +49,7 @@ func TestPromoteAllReleasesFromStagingToProd(t *testing.T) {
 	defer ctrl.Finish()
 
 	promptProvider := promote.NewMockPromptProvider(ctrl)
-	promptProvider.EXPECT().SelectReleases(gomock.Any()).DoAndReturn(func(list *cross.ReleaseList) (*cross.ReleaseList, error) { return list, nil })
+	promptProvider.EXPECT().SelectReleases(gomock.Any(), gomock.Any()).DoAndReturn(func(list *cross.ReleaseList, maxColumnWidth int) (*cross.ReleaseList, error) { return list, nil })
 	promptProvider.EXPECT().PrintStartPreview()
 	promptProvider.EXPECT().PrintReleasePreview(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 	promptProvider.EXPECT().PrintReleasePreview(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
@@ -108,7 +108,7 @@ func TestPromoteAutoMergeFromStagingToProd(t *testing.T) {
 	defer ctrl.Finish()
 
 	promptProvider := promote.NewMockPromptProvider(ctrl)
-	promptProvider.EXPECT().SelectReleases(gomock.Any()).DoAndReturn(func(list *cross.ReleaseList) (*cross.ReleaseList, error) { return list, nil })
+	promptProvider.EXPECT().SelectReleases(gomock.Any(), gomock.Any()).DoAndReturn(func(list *cross.ReleaseList, maxColumnWidth int) (*cross.ReleaseList, error) { return list, nil })
 	promptProvider.EXPECT().PrintStartPreview()
 	promptProvider.EXPECT().PrintReleasePreview(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 	promptProvider.EXPECT().PrintReleasePreview(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
@@ -248,7 +248,7 @@ func TestDraftPromoteFromStagingToProd(t *testing.T) {
 	defer ctrl.Finish()
 
 	promptProvider := promote.NewMockPromptProvider(ctrl)
-	promptProvider.EXPECT().SelectReleases(gomock.Any()).DoAndReturn(func(list *cross.ReleaseList) (*cross.ReleaseList, error) { return list, nil })
+	promptProvider.EXPECT().SelectReleases(gomock.Any(), gomock.Any()).DoAndReturn(func(list *cross.ReleaseList, maxColumnWidth int) (*cross.ReleaseList, error) { return list, nil })
 	promptProvider.EXPECT().PrintStartPreview()
 	promptProvider.EXPECT().PrintReleasePreview(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 	promptProvider.EXPECT().PrintReleasePreview(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())

--- a/internal/release/promote/test/promotion_test.go
+++ b/internal/release/promote/test/promotion_test.go
@@ -128,7 +128,7 @@ func TestPromotion(t *testing.T) {
 				crossRel0.Releases[sourceEnvIndex] = sourceRelease
 				crossRel0.Releases[targetEnvIndex] = targetRelease
 
-				args.promptProvider.EXPECT().SelectReleases(gomock.Any()).DoAndReturn(func(list *cross.ReleaseList) (*cross.ReleaseList, error) { return list, nil })
+				args.promptProvider.EXPECT().SelectReleases(gomock.Any(), gomock.Any()).DoAndReturn(func(list *cross.ReleaseList, maxColumnWidth int) (*cross.ReleaseList, error) { return list, nil })
 				args.promptProvider.EXPECT().PrintStartPreview()
 				args.promptProvider.EXPECT().PrintReleasePreview(targetEnv.Name, crossRel0.Name, targetRelease.File, expectedPromotedFile)
 				args.promptProvider.EXPECT().PrintEndPreview()
@@ -181,7 +181,7 @@ func TestPromotion(t *testing.T) {
 
 				expectedPromotedFile.Path = fmt.Sprintf("%s/releases/testing/test.yaml", targetEnv.Dir)
 
-				args.promptProvider.EXPECT().SelectReleases(gomock.Any()).DoAndReturn(func(list *cross.ReleaseList) (*cross.ReleaseList, error) { return list, nil })
+				args.promptProvider.EXPECT().SelectReleases(gomock.Any(), gomock.Any()).DoAndReturn(func(list *cross.ReleaseList, maxColumnWidth int) (*cross.ReleaseList, error) { return list, nil })
 				args.promptProvider.EXPECT().PrintStartPreview()
 				args.promptProvider.EXPECT().PrintReleasePreview(targetEnv.Name, crossRel0.Name, nil, expectedPromotedFile)
 				args.promptProvider.EXPECT().PrintEndPreview()


### PR DESCRIPTION
Adds `--narrow` and `--wide` column modes to `joy rel ls` and `joy rel prom`.  Defaults are as follow and can be overridden in user's `.joyrc` file:
```
columnWidths:
  narrow: 20
  normal: 40
  wide: 80
```