### PR TITLE
fix(PL-2582): fix build promote

### DIFF
--- a/cmd/joy/build.go
+++ b/cmd/joy/build.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/nestoca/joy/internal/build"
+	"github.com/nestoca/joy/internal/yml"
 	"github.com/nestoca/joy/pkg/catalog"
 )
 
@@ -40,6 +41,7 @@ Usage: joy build promote <env> <project> <version>`,
 				Environment: env,
 				Project:     project,
 				Version:     version,
+				Writer:      yml.DiskWriter,
 			})
 		},
 	}

--- a/internal/build/promote.go
+++ b/internal/build/promote.go
@@ -28,8 +28,13 @@ func Promote(opts Opts) error {
 	}
 
 	promotionCount := 0
+	releaseIndex := opts.Catalog.Releases.GetEnvironmentIndexByName(opts.Environment)
 	for _, crossRelease := range opts.Catalog.Releases.Items {
-		release := crossRelease.Releases[0]
+		release := crossRelease.Releases[releaseIndex]
+		if release == nil {
+			// The release may not be present in the target environment
+			continue
+		}
 		if release.Spec.Project == opts.Project {
 			versionNode, err := yml.FindNode(release.File.Tree, "spec.version")
 			if err != nil {

--- a/internal/build/promote_test.go
+++ b/internal/build/promote_test.go
@@ -14,10 +14,12 @@ import (
 func TestPromote(t *testing.T) {
 	var writer yml.WriterMock
 
+	environments := []*v1alpha1.Environment{{}}
 	opts := Opts{
 		Catalog: &catalog.Catalog{
-			Environments: []*v1alpha1.Environment{{}},
+			Environments: environments,
 			Releases: cross.ReleaseList{
+				Environments: environments,
 				Items: []*cross.Release{
 					{
 						Releases: []*v1alpha1.Release{

--- a/internal/release/cross/release_list.go
+++ b/internal/release/cross/release_list.go
@@ -81,8 +81,8 @@ func findEnvironmentForReleaseFile(environments []*v1alpha1.Environment, release
 	return nil
 }
 
-// getEnvironmentIndexByName returns the index of the environment with the given name or -1 if not found.
-func (r *ReleaseList) getEnvironmentIndexByName(name string) int {
+// GetEnvironmentIndexByName returns the index of the environment with the given name or -1 if not found.
+func (r *ReleaseList) GetEnvironmentIndexByName(name string) int {
 	for i, env := range r.Environments {
 		if env.Name == name {
 			return i
@@ -113,7 +113,7 @@ func (r *ReleaseList) getReleaseIndex(name string) int {
 // addRelease adds a release to given environment.
 func (r *ReleaseList) addRelease(rel *v1alpha1.Release, environment *v1alpha1.Environment) error {
 	// Find environment index
-	environmentIndex := r.getEnvironmentIndexByName(environment.Name)
+	environmentIndex := r.GetEnvironmentIndexByName(environment.Name)
 	if environmentIndex == -1 {
 		return fmt.Errorf("environment %s not found in list", environment.Name)
 	}
@@ -155,8 +155,8 @@ func (r *ReleaseList) OnlySpecificReleases(releases []string) ReleaseList {
 // GetReleasesForPromotion returns a subset of the releases in this list that are promotable,
 // with only the given source and target environments as first and second environments.
 func (r *ReleaseList) GetReleasesForPromotion(sourceEnv, targetEnv *v1alpha1.Environment) (ReleaseList, error) {
-	sourceEnvIndex := r.getEnvironmentIndexByName(sourceEnv.Name)
-	targetEnvIndex := r.getEnvironmentIndexByName(targetEnv.Name)
+	sourceEnvIndex := r.GetEnvironmentIndexByName(sourceEnv.Name)
+	targetEnvIndex := r.GetEnvironmentIndexByName(targetEnv.Name)
 	subset := MakeReleaseList([]*v1alpha1.Environment{sourceEnv, targetEnv})
 	for _, item := range r.Items {
 		// Determine source and target releases
@@ -184,7 +184,7 @@ func (r *ReleaseList) GetNonPromotableReleases(sourceEnv, targetEnv *v1alpha1.En
 	}
 
 	var invalidList []string
-	sourceEnvIndex := r.getEnvironmentIndexByName(sourceEnv.Name)
+	sourceEnvIndex := r.GetEnvironmentIndexByName(sourceEnv.Name)
 
 	for _, item := range r.Items {
 		sourceRelease := item.Releases[sourceEnvIndex]


### PR DESCRIPTION
1d3c9fb4350cc5a18e33bc78e15ea59e02da57d5 broke `build promote`    in a few ways:

 - Did not have a writer

 - Releases items now are in an array where the index is set per environment. Not all environments may have a release. Note: Why not using a map?