### PR TITLE
feat(PL-2602): joy rel ls --json

### DIFF
--- a/internal/git/clean_working_copy.go
+++ b/internal/git/clean_working_copy.go
@@ -3,6 +3,7 @@ package git
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/nestoca/joy/internal/config"
@@ -11,7 +12,7 @@ import (
 
 func EnsureCleanAndUpToDateWorkingCopy(ctx context.Context) error {
 	if config.FlagsFromContext(ctx).SkipCatalogUpdate {
-		fmt.Println("ℹ️ Skipping catalog update and dirty check.")
+		_, _ = fmt.Fprintln(os.Stderr, "ℹ️ Skipping catalog update and dirty check.")
 		return nil
 	}
 
@@ -22,14 +23,14 @@ func EnsureCleanAndUpToDateWorkingCopy(ctx context.Context) error {
 		return fmt.Errorf("getting uncommitted changes: %w", err)
 	}
 	if len(changes) > 0 {
-		return fmt.Errorf("uncommitted changes detected:\n%s", style.Warning(strings.Join(changes, "\n")))
+		return fmt.Errorf("uncommitted catalog changes detected:\n%s", style.Warning(strings.Join(changes, "\n")))
 	}
 
 	const defaultBranch = "master"
 	if err = Checkout(dir, defaultBranch); err != nil {
 		return fmt.Errorf("checking out default branch: %w", err)
 	}
-	fmt.Printf("ℹ️ Catalog: checking out %s branch\n", style.Code(defaultBranch))
+	_, _ = fmt.Fprintf(os.Stderr, "ℹ️ Catalog: checking out %s branch\n", style.Code(defaultBranch))
 
 	if err = Pull(dir); err != nil {
 		return fmt.Errorf("pulling changes: %w", err)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -182,8 +182,7 @@ func PushNewBranch(dir, name string) error {
 func Pull(dir string, args ...string) error {
 	args = append([]string{"-C", dir, "pull"}, args...)
 	cmd := exec.Command("git", args...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
+	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()
 	if err != nil {


### PR DESCRIPTION
See documentation [here](https://nestoca.atlassian.net/wiki/spaces/DEVOPS/pages/2669936744/Internal+Developer+Platform#How-to-create-your-own-joy-extension-scripts) for an example script that uses `joy rel ls --json`.

Actually, here it is:
```
#!/usr/bin/env bash
joy release list --env staging --json 2>/dev/null | 
    jq -r '.crossReleases[] | select(.name == "accounts") | .releases[] | select(.status == "ahead") | "\(.metadata.name): \(.version)"'
```

It would be great to internally do the equivalent of `2>/dev/null` for `--json` output, otherwise it clutters up the output (even if it's now sent to `stderr`, the user still sees it).