### PR TITLE
fix(PL2614): update catalog and config on catalog pull

### DIFF
--- a/cmd/joy/project.go
+++ b/cmd/joy/project.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/nestoca/joy/internal/config"
-	"github.com/nestoca/joy/internal/git"
 	"github.com/nestoca/joy/internal/info"
 	"github.com/nestoca/joy/internal/jac"
 	"github.com/nestoca/joy/internal/links"
@@ -15,7 +14,7 @@ import (
 	"github.com/nestoca/joy/pkg/catalog"
 )
 
-func NewProjectCmd() *cobra.Command {
+func NewProjectCmd(preRunConfigs PreRunConfigs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "projects",
 		Aliases: []string{"project", "proj"},
@@ -23,14 +22,14 @@ func NewProjectCmd() *cobra.Command {
 		Long:    `Manage projects, such as listing and selecting them.`,
 		GroupID: "core",
 	}
-	cmd.AddCommand(NewProjectListCmd())
-	cmd.AddCommand(NewProjectPeopleCmd())
+	cmd.AddCommand(NewProjectListCmd(preRunConfigs))
+	cmd.AddCommand(NewProjectPeopleCmd(preRunConfigs))
 	cmd.AddCommand(NewProjectOpenCmd())
 	cmd.AddCommand(NewProjectLinksCmd())
 	return cmd
 }
 
-func NewProjectPeopleCmd() *cobra.Command {
+func NewProjectPeopleCmd(preRunConfigs PreRunConfigs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "owners",
 		Short: "List people owning a project via jac cli",
@@ -49,18 +48,18 @@ This command requires the jac cli: https://github.com/nestoca/jac
 		},
 		Args:               cobra.ArbitraryArgs,
 		DisableFlagParsing: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return git.EnsureCleanAndUpToDateWorkingCopy(cmd.Context())
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cat := catalog.FromContext(cmd.Context())
 			return jac.ListProjectPeople(cat, args)
 		},
 	}
+
+	preRunConfigs.PullCatalog(cmd)
+
 	return cmd
 }
 
-func NewProjectListCmd() *cobra.Command {
+func NewProjectListCmd(preRunConfigs PreRunConfigs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List projects and their owners",
@@ -68,14 +67,12 @@ func NewProjectListCmd() *cobra.Command {
 			"ls",
 		},
 		Long: `List projects and their owners.`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return git.EnsureCleanAndUpToDateWorkingCopy(cmd.Context())
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cat := catalog.FromContext(cmd.Context())
 			return project.List(cat)
 		},
 	}
+	preRunConfigs.PullCatalog(cmd)
 	return cmd
 }
 

--- a/cmd/joy/root_test.go
+++ b/cmd/joy/root_test.go
@@ -27,16 +27,20 @@ func TestRootVersions(t *testing.T) {
 		ExpectedError string
 	}{
 		{
-			Name:          "less than min",
-			MinVersion:    "v1.0.0",
-			Version:       "v0.0.7",
-			ExpectedError: `current version "v0.0.7" is less than required minimum version "v1.0.0"`,
+			Name:       "less than min",
+			MinVersion: "v1.0.0",
+			Version:    "v0.0.7",
+			ExpectedError: `Current version "v0.0.7" is less than required minimum version "v1.0.0"
+
+Please update joy! >> brew update && brew upgrade joy`,
 		},
 		{
-			Name:          "prerelease",
-			MinVersion:    "v1.0.0",
-			Version:       "v1.0.0-alpha",
-			ExpectedError: `current version "v1.0.0-alpha" is less than required minimum version "v1.0.0"`,
+			Name:       "prerelease",
+			MinVersion: "v1.0.0",
+			Version:    "v1.0.0-alpha",
+			ExpectedError: `Current version "v1.0.0-alpha" is less than required minimum version "v1.0.0"
+
+Please update joy! >> brew update && brew upgrade joy`,
 		},
 		{
 			Name:       "equal to min",

--- a/internal/git/clean_working_copy.go
+++ b/internal/git/clean_working_copy.go
@@ -1,24 +1,15 @@
 package git
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strings"
 
-	"github.com/nestoca/joy/internal/config"
 	"github.com/nestoca/joy/internal/style"
 )
 
-func EnsureCleanAndUpToDateWorkingCopy(ctx context.Context) error {
-	if config.FlagsFromContext(ctx).SkipCatalogUpdate {
-		_, _ = fmt.Fprintln(os.Stderr, "ℹ️ Skipping catalog update and dirty check.")
-		return nil
-	}
-
-	dir := config.FromContext(ctx).CatalogDir
-
-	changes, err := GetUncommittedChanges(dir)
+func EnsureCleanAndUpToDateWorkingCopy(catalogDir string) error {
+	changes, err := GetUncommittedChanges(catalogDir)
 	if err != nil {
 		return fmt.Errorf("getting uncommitted changes: %w", err)
 	}
@@ -27,12 +18,12 @@ func EnsureCleanAndUpToDateWorkingCopy(ctx context.Context) error {
 	}
 
 	const defaultBranch = "master"
-	if err = Checkout(dir, defaultBranch); err != nil {
+	if err = Checkout(catalogDir, defaultBranch); err != nil {
 		return fmt.Errorf("checking out default branch: %w", err)
 	}
 	_, _ = fmt.Fprintf(os.Stderr, "ℹ️ Catalog: checking out %s branch\n", style.Code(defaultBranch))
 
-	if err = Pull(dir); err != nil {
+	if err = Pull(catalogDir); err != nil {
 		return fmt.Errorf("pulling changes: %w", err)
 	}
 


### PR DESCRIPTION
This PR updates the EnsureCleanAndUpToDateWorkingCopy function such that it will update the config and catalog context objects.

The one issue with this approach is that we don't run the same checks as the root, such as checking joy min Versions, etc.

However we weren't doing so before, so this is not a regression. But we will need to think on it for a future task.
