### PR TITLE
feat/PL 2736/render many releases

### DIFF
--- a/cmd/joy/build.go
+++ b/cmd/joy/build.go
@@ -34,7 +34,8 @@ Usage: joy build promote <env> <project> <version>`,
 			project := args[1]
 			version := args[2]
 
-			cat := catalog.FromContext(cmd.Context()).WithEnvironments([]string{env})
+			cat := catalog.FromContext(cmd.Context())
+			cat.WithEnvironments([]string{env})
 
 			return build.Promote(build.Opts{
 				Catalog:     cat,

--- a/cmd/joy/release_render_test.go
+++ b/cmd/joy/release_render_test.go
@@ -57,7 +57,7 @@ func TestReleaseRender(t *testing.T) {
 		cmd.SetErr(&buffer)
 		cmd.SetArgs([]string{"--color=false", "--env=testing", "does-not-exist"})
 
-		require.EqualError(t, cmd.ExecuteContext(ctx), "getting release: not found: does-not-exist")
+		require.EqualError(t, cmd.ExecuteContext(ctx), "unknown release(s): does-not-exist")
 	})
 
 	t.Run("diff", func(t *testing.T) {
@@ -89,6 +89,7 @@ func TestReleaseRender(t *testing.T) {
 		})
 
 		err = cmd.ExecuteContext(ctx)
+		t.Log(buffer.String())
 		require.NoError(t, err, buffer.String())
 
 		var removals, additions []string
@@ -224,6 +225,6 @@ func TestReleaseRender(t *testing.T) {
 		})
 
 		err = cmd.ExecuteContext(ctx)
-		require.EqualError(t, err, "getting release: not found: does-not-exist")
+		require.EqualError(t, err, "unknown release(s): does-not-exist")
 	})
 }

--- a/internal/prompt.go
+++ b/internal/prompt.go
@@ -1,0 +1,22 @@
+package internal
+
+import (
+	"slices"
+
+	"github.com/nestoca/survey/v2"
+)
+
+func MultiSelect(msg string, options []string) ([]string, error) {
+	options = append([]string{}, options...)
+	slices.Sort(options)
+
+	ms := &survey.MultiSelect{
+		Message: msg,
+		Options: options,
+	}
+
+	var answer []string
+	err := survey.AskOne(ms, &answer)
+
+	return answer, err
+}

--- a/internal/release/render/render_test.go
+++ b/internal/release/render/render_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -14,29 +15,26 @@ import (
 	"github.com/nestoca/joy/api/v1alpha1"
 	"github.com/nestoca/joy/internal"
 	"github.com/nestoca/joy/internal/config"
-	"github.com/nestoca/joy/internal/release/cross"
-	"github.com/nestoca/joy/pkg/catalog"
 	"github.com/nestoca/joy/pkg/helm"
 )
 
-func TestRender(t *testing.T) {
+func TestRenderRelease(t *testing.T) {
 	type RenderTestParams struct {
-		Env            string
-		Release        string
-		DefaultChart   string
-		CacheDir       string
-		Catalog        *catalog.Catalog
-		IO             internal.IO
-		SetupHelmMock  func(*helm.PullRendererMock)
-		HelmAssertions func(*testing.T, *helm.PullRendererMock)
-		ValueMapping   *config.ValueMapping
+		Release       *v1alpha1.Release
+		ChartFS       func(*xfs.FSMock) func(*testing.T)
+		IO            internal.IO
+		SetupHelmMock func(*helm.PullRendererMock) func(*testing.T)
+		ValueMapping  *config.ValueMapping
 	}
 
-	var (
-		stdout bytes.Buffer
-		stderr bytes.Buffer
-		stdin  bytes.Buffer
-	)
+	var stdout bytes.Buffer
+
+	buildRelease := func(env, name string) *v1alpha1.Release {
+		return &v1alpha1.Release{
+			ReleaseMetadata: v1alpha1.ReleaseMetadata{Name: name},
+			Environment:     &v1alpha1.Environment{EnvironmentMetadata: v1alpha1.EnvironmentMetadata{Name: env}},
+		}
+	}
 
 	cases := []struct {
 		Name          string
@@ -45,456 +43,141 @@ func TestRender(t *testing.T) {
 		ExpectedOut   string
 	}{
 		{
-			Name: "env not found",
-			Params: RenderTestParams{
-				Env: "quality-assurance",
-				Catalog: &catalog.Catalog{
-					Environments: []*v1alpha1.Environment{
-						{EnvironmentMetadata: v1alpha1.EnvironmentMetadata{Name: "qa"}},
-					},
-				},
-			},
-			ExpectedError: "getting environment: not found: quality-assurance",
-		},
-		{
-			Name: "release not found",
-			Params: RenderTestParams{
-				Env:     "qa",
-				Release: "app",
-				Catalog: &catalog.Catalog{
-					Environments: []*v1alpha1.Environment{
-						{EnvironmentMetadata: v1alpha1.EnvironmentMetadata{Name: "qa"}},
-					},
-					Releases: cross.ReleaseList{},
-				},
-			},
-			ExpectedError: "getting release: not found: app",
-		},
-		{
-			Name: "release not found in env",
-			Params: RenderTestParams{
-				Env:     "qa",
-				Release: "app",
-				Catalog: &catalog.Catalog{
-					Environments: []*v1alpha1.Environment{
-						{EnvironmentMetadata: v1alpha1.EnvironmentMetadata{Name: "qa"}},
-					},
-					Releases: cross.ReleaseList{
-						Items: []*cross.Release{
-							{
-								Name: "app",
-								Releases: []*v1alpha1.Release{
-									{Environment: &v1alpha1.Environment{EnvironmentMetadata: v1alpha1.EnvironmentMetadata{Name: "prod"}}},
-								},
-							},
-						},
-					},
-				},
-			},
-			ExpectedError: "getting release: not found within environment qa: app",
-		},
-		{
-			Name: "pull fails",
-			Params: RenderTestParams{
-				Env:     "qa",
-				Release: "app",
-				Catalog: &catalog.Catalog{
-					Environments: []*v1alpha1.Environment{
-						{EnvironmentMetadata: v1alpha1.EnvironmentMetadata{Name: "qa"}},
-					},
-					Releases: cross.ReleaseList{
-						Items: []*cross.Release{
-							{
-								Name: "app",
-								Releases: []*v1alpha1.Release{
-									{
-										Spec: v1alpha1.ReleaseSpec{
-											Chart: v1alpha1.ReleaseChart{
-												Version: "v1",
-												Name:    "name",
-												RepoUrl: "url",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				CacheDir: "~/.cache/joy/does_not_exist",
-				SetupHelmMock: func(mock *helm.PullRendererMock) {
-					mock.PullFunc = func(contextMoqParam context.Context, pullOptions helm.PullOptions) error {
-						return errors.New("some informative error")
-					}
-				},
-				HelmAssertions: func(t *testing.T, mock *helm.PullRendererMock) {
-					require.Len(t, mock.PullCalls(), 1)
-					require.Equal(
-						t,
-						helm.PullOptions{
-							Chart: helm.Chart{
-								RepoURL: "url",
-								Name:    "name",
-								Version: "v1",
-							},
-							OutputDir: "~/.cache/joy/does_not_exist/url/name/v1",
-						},
-						mock.PullCalls()[0].PullOptions,
-					)
-				},
-			},
-			ExpectedError: "getting release chart: pulling chart: some informative error",
-		},
-		{
-			Name: "pull fails with default chart",
-			Params: RenderTestParams{
-				Env:     "qa",
-				Release: "app",
-				Catalog: &catalog.Catalog{
-					Environments: []*v1alpha1.Environment{
-						{EnvironmentMetadata: v1alpha1.EnvironmentMetadata{Name: "qa"}},
-					},
-					Releases: cross.ReleaseList{
-						Items: []*cross.Release{
-							{
-								Name: "app",
-								Releases: []*v1alpha1.Release{
-									{
-										Spec: v1alpha1.ReleaseSpec{
-											Chart: v1alpha1.ReleaseChart{
-												Version: "v666",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				DefaultChart: "generic",
-				CacheDir:     "~/.cache/joy/does_not_exist",
-				SetupHelmMock: func(mock *helm.PullRendererMock) {
-					mock.PullFunc = func(contextMoqParam context.Context, pullOptions helm.PullOptions) error {
-						return errors.New("some informative error")
-					}
-				},
-				HelmAssertions: func(t *testing.T, mock *helm.PullRendererMock) {
-					require.Len(t, mock.PullCalls(), 1)
-					require.Equal(
-						t,
-						helm.PullOptions{
-							Chart: helm.Chart{
-								RepoURL: "default",
-								Name:    "chart",
-								Version: "v666",
-							},
-							OutputDir: "~/.cache/joy/does_not_exist/default/chart/v666",
-						},
-						mock.PullCalls()[0].PullOptions,
-					)
-				},
-			},
-			ExpectedError: "getting release chart: pulling chart: some informative error",
-		},
-		{
 			Name: "fail to hydrate values",
 			Params: RenderTestParams{
-				Env:     "qa",
-				Release: "app",
-				Catalog: &catalog.Catalog{
-					Environments: []*v1alpha1.Environment{
-						{EnvironmentMetadata: v1alpha1.EnvironmentMetadata{Name: "qa"}},
-					},
-					Releases: cross.ReleaseList{
-						Items: []*cross.Release{
-							{
-								Name: "app",
-								Releases: []*v1alpha1.Release{
-									{
-										ReleaseMetadata: v1alpha1.ReleaseMetadata{Name: "app"},
-										Spec: v1alpha1.ReleaseSpec{
-											Version: "v1.2.3",
-											Values: map[string]any{
-												"env":     "{{ .Environment.Name `!}}",
-												"version": "{{ .Release.Spec.Version }}",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
+				Release: buildRelease("env", "release"),
+				ChartFS: func(f *xfs.FSMock) func(*testing.T) {
+					return func(t *testing.T) {}
 				},
-				DefaultChart: "generic",
-				CacheDir:     "~/.cache/joy/does_not_exist",
+				ValueMapping: &config.ValueMapping{Mappings: map[string]any{
+					"image.tag": "{{ .Release.Spec.version }",
+				}},
 			},
-			ExpectedError: "hydrating values: template: :1: unterminated raw quoted string",
+			ExpectedError: `hydrating values: template: :2: unexpected "}" in operand`,
 		},
 		{
 			Name: "fail to render",
 			Params: RenderTestParams{
-				Env:     "qa",
-				Release: "app",
-				Catalog: &catalog.Catalog{
-					Environments: []*v1alpha1.Environment{
-						{EnvironmentMetadata: v1alpha1.EnvironmentMetadata{Name: "qa"}},
-					},
-					Releases: cross.ReleaseList{
-						Items: []*cross.Release{
-							{
-								Name: "app",
-								Releases: []*v1alpha1.Release{
-									{
-										ReleaseMetadata: v1alpha1.ReleaseMetadata{Name: "app"},
-										Spec: v1alpha1.ReleaseSpec{
-											Version: "v1.2.3",
-											Values: map[string]any{
-												"env":     "{{ .Environment.Name }}",
-												"version": "{{ .Release.Spec.Version }}",
-											},
-										},
-									},
-								},
+				Release: buildRelease("env", "release"),
+				SetupHelmMock: func(mock *helm.PullRendererMock) func(*testing.T) {
+					mock.RenderFunc = func(ctx context.Context, opts helm.RenderOpts) (string, error) {
+						return "", errors.New("bebop")
+					}
+
+					return func(t *testing.T) {
+						require.Len(t, mock.RenderCalls(), 1)
+						require.Equal(
+							t,
+							helm.RenderOpts{
+								ReleaseName: "release",
+								Values:      map[string]interface{}{},
+								ChartPath:   "path/to/chart",
 							},
-						},
-					},
-				},
-				DefaultChart: "generic",
-				CacheDir:     "~/.cache/joy/does_not_exist",
-				SetupHelmMock: func(mock *helm.PullRendererMock) {
-					mock.RenderFunc = func(ctx context.Context, opts helm.RenderOpts) error {
-						return errors.New("bebop")
+							mock.RenderCalls()[0].Opts,
+						)
 					}
 				},
-				HelmAssertions: func(t *testing.T, mock *helm.PullRendererMock) {
-					require.Len(t, mock.PullCalls(), 1)
-					require.Equal(
-						t,
-						helm.PullOptions{
-							Chart: helm.Chart{
-								RepoURL: "default",
-								Name:    "chart",
-								Version: "v1",
-							},
-							OutputDir: "~/.cache/joy/does_not_exist/default/chart/v1",
-						},
-						mock.PullCalls()[0].PullOptions,
-					)
-					require.Len(t, mock.RenderCalls(), 1)
-					require.Equal(
-						t,
-						helm.RenderOpts{
-							Dst:         &stdout,
-							ReleaseName: "app",
-							ChartPath:   "~/.cache/joy/does_not_exist/default/chart/v1/chart",
-							Values: map[string]any{
-								"env":     "qa",
-								"version": "v1.2.3",
-							},
-						},
-						mock.RenderCalls()[0].Opts,
-					)
-				},
 			},
-			ExpectedError: "rendering chart: bebop",
+			ExpectedError: "bebop",
 		},
 		{
 			Name: "render with chart mappings",
 			Params: RenderTestParams{
-				Env:     "qa",
-				Release: "app",
-				Catalog: &catalog.Catalog{
-					Environments: []*v1alpha1.Environment{
-						{EnvironmentMetadata: v1alpha1.EnvironmentMetadata{Name: "qa"}},
-					},
-					Releases: cross.ReleaseList{
-						Items: []*cross.Release{
-							{
-								Name: "app",
-								Releases: []*v1alpha1.Release{
-									{
-										ReleaseMetadata: v1alpha1.ReleaseMetadata{Name: "app"},
-										Spec: v1alpha1.ReleaseSpec{
-											Version: "v1.2.3",
-											Values: map[string]any{
-												"env":     "{{ .Environment.Name }}",
-												"version": "{{ .Release.Spec.Version }}",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
+				Release: func() *v1alpha1.Release {
+					rel := buildRelease("env", "release")
+					rel.Spec.Version = "v1.2.3"
+					return rel
+				}(),
 				ValueMapping: &config.ValueMapping{Mappings: map[string]any{
 					"image.tag":             "{{ .Release.Spec.Version }}",
 					`annotations.nesto\.ca`: true,
 				}},
-				DefaultChart: "generic",
-				CacheDir:     "~/.cache/joy/does_not_exist",
-				HelmAssertions: func(t *testing.T, mock *helm.PullRendererMock) {
-					require.Len(t, mock.PullCalls(), 1)
-					require.Equal(
-						t,
-						helm.PullOptions{
-							Chart: helm.Chart{
-								RepoURL: "default",
-								Name:    "chart",
-								Version: "v1",
+				SetupHelmMock: func(mock *helm.PullRendererMock) func(*testing.T) {
+					return func(t *testing.T) {
+						require.Len(t, mock.RenderCalls(), 1)
+						require.Equal(
+							t,
+							helm.RenderOpts{
+								ReleaseName: "release",
+								Values: map[string]any{
+									"annotations": map[string]any{"nesto.ca": true},
+									"image":       map[string]any{"tag": "v1.2.3"},
+								},
+								ChartPath: "path/to/chart",
 							},
-							OutputDir: "~/.cache/joy/does_not_exist/default/chart/v1",
-						},
-						mock.PullCalls()[0].PullOptions,
-					)
-					require.Len(t, mock.RenderCalls(), 1)
-					require.Equal(
-						t,
-						helm.RenderOpts{
-							Dst:         &stdout,
-							ReleaseName: "app",
-							ChartPath:   "~/.cache/joy/does_not_exist/default/chart/v1/chart",
-							Values: map[string]any{
-								"env":         "qa",
-								"version":     "v1.2.3",
-								"image":       map[string]any{"tag": "v1.2.3"},
-								"annotations": map[string]any{"nesto.ca": true},
-							},
-						},
-						mock.RenderCalls()[0].Opts,
-					)
+							mock.RenderCalls()[0].Opts,
+						)
+					}
 				},
 			},
 		},
 		{
 			Name: "render with ignored chart mappings",
 			Params: RenderTestParams{
-				Env:     "qa",
-				Release: "app",
-				Catalog: &catalog.Catalog{
-					Environments: []*v1alpha1.Environment{
-						{EnvironmentMetadata: v1alpha1.EnvironmentMetadata{Name: "qa"}},
-					},
-					Releases: cross.ReleaseList{
-						Items: []*cross.Release{
-							{
-								Name: "app",
-								Releases: []*v1alpha1.Release{
-									{
-										ReleaseMetadata: v1alpha1.ReleaseMetadata{Name: "app"},
-										Spec: v1alpha1.ReleaseSpec{
-											Version: "v1.2.3",
-											Values: map[string]any{
-												"env":     "{{ .Environment.Name }}",
-												"version": "{{ .Release.Spec.Version }}",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
+				Release: func() *v1alpha1.Release {
+					rel := buildRelease("env", "release")
+					rel.Spec.Version = "v1.2.3"
+					return rel
+				}(),
 				ValueMapping: &config.ValueMapping{
-					ReleaseIgnoreList: []string{"app"},
+					ReleaseIgnoreList: []string{"release"},
 					Mappings: map[string]any{
 						"image.tag":             "{{ .Release.Spec.Version }}",
 						`annotations.nesto\.ca`: true,
 					},
 				},
-				DefaultChart: "generic",
-				CacheDir:     "~/.cache/joy/does_not_exist",
-				HelmAssertions: func(t *testing.T, mock *helm.PullRendererMock) {
-					require.Len(t, mock.PullCalls(), 1)
-					require.Equal(
-						t,
-						helm.PullOptions{
-							Chart: helm.Chart{
-								RepoURL: "default",
-								Name:    "chart",
-								Version: "v1",
+				SetupHelmMock: func(mock *helm.PullRendererMock) func(*testing.T) {
+					return func(t *testing.T) {
+						require.Len(t, mock.RenderCalls(), 1)
+						require.Equal(
+							t,
+							helm.RenderOpts{
+								ReleaseName: "release",
+								Values:      map[string]any{},
+								ChartPath:   "path/to/chart",
 							},
-							OutputDir: "~/.cache/joy/does_not_exist/default/chart/v1",
-						},
-						mock.PullCalls()[0].PullOptions,
-					)
-					require.Len(t, mock.RenderCalls(), 1)
-					require.Equal(
-						t,
-						helm.RenderOpts{
-							Dst:         &stdout,
-							ReleaseName: "app",
-							ChartPath:   "~/.cache/joy/does_not_exist/default/chart/v1/chart",
-							Values: map[string]any{
-								"env":     "qa",
-								"version": "v1.2.3",
-							},
-						},
-						mock.RenderCalls()[0].Opts,
-					)
+							mock.RenderCalls()[0].Opts,
+						)
+					}
 				},
 			},
 		},
 		{
 			Name: "render with environment-level values",
 			Params: RenderTestParams{
-				Env:     "qa",
-				Release: "app",
-				Catalog: &catalog.Catalog{
-					Environments: []*v1alpha1.Environment{
-						{
-							EnvironmentMetadata: v1alpha1.EnvironmentMetadata{Name: "qa"},
-							Spec:                v1alpha1.EnvironmentSpec{Values: map[string]any{"corsOrigins": []any{"origin1.com", "origin2.com"}}},
-						},
-					},
-					Releases: cross.ReleaseList{
-						Items: []*cross.Release{
-							{
-								Name: "app",
-								Releases: []*v1alpha1.Release{
-									{
-										ReleaseMetadata: v1alpha1.ReleaseMetadata{Name: "app"},
-										Spec: v1alpha1.ReleaseSpec{
-											Version: "1.2.3",
-											Values: map[string]any{
-												"env":         "{{ .Environment.Name }}",
-												"version":     "{{ .Release.Spec.Version }}",
-												"corsOrigins": "$ref(.Environment.Spec.Values.corsOrigins)",
-											},
-										},
-									},
+				Release: func() *v1alpha1.Release {
+					rel := buildRelease("env", "release")
+					rel.Spec.Values = map[string]any{
+						"env":         "{{ .Environment.Name }}",
+						"version":     "{{ .Release.Spec.Version }}",
+						"corsOrigins": "$ref(.Environment.Spec.Values.corsOrigins)",
+					}
+					rel.Spec.Version = "v1.2.3"
+					rel.Environment.Spec.Values = map[string]any{
+						"corsOrigins": []any{"origin1.com", "origin2.com"},
+					}
+					return rel
+				}(),
+				SetupHelmMock: func(mock *helm.PullRendererMock) func(*testing.T) {
+					return func(t *testing.T) {
+						require.Len(t, mock.RenderCalls(), 1)
+						require.Equal(
+							t,
+							helm.RenderOpts{
+								ReleaseName: "release",
+								Values: map[string]interface{}{
+									"corsOrigins": []interface{}{"origin1.com", "origin2.com"},
+									"env":         "env",
+									"version":     "v1.2.3",
 								},
+								ChartPath: "path/to/chart",
 							},
-						},
-					},
-				},
-				DefaultChart: "generic",
-				CacheDir:     "~/.cache/joy/does_not_exist",
-				HelmAssertions: func(t *testing.T, mock *helm.PullRendererMock) {
-					require.Len(t, mock.RenderCalls(), 1)
-					require.Equal(
-						t,
-						helm.RenderOpts{
-							Dst:         &stdout,
-							ReleaseName: "app",
-							ChartPath:   "~/.cache/joy/does_not_exist/default/chart/v1/chart",
-							Values: map[string]any{
-								"env":         "qa",
-								"version":     "1.2.3",
-								"corsOrigins": []any{"origin1.com", "origin2.com"},
-							},
-						},
-						mock.RenderCalls()[0].Opts,
-					)
+							mock.RenderCalls()[0].Opts,
+						)
+					}
 				},
 			},
 		},
-	}
-
-	io := internal.IO{
-		Out: &stdout,
-		Err: &stderr,
-		In:  &stdin,
 	}
 
 	for _, tc := range cases {
@@ -504,48 +187,43 @@ func TestRender(t *testing.T) {
 			helmMock := new(helm.PullRendererMock)
 
 			if setup := tc.Params.SetupHelmMock; setup != nil {
-				setup(helmMock)
-			}
-			if assertions := tc.Params.HelmAssertions; assertions != nil {
-				defer assertions(t, helmMock)
+				defer setup(helmMock)(t)
 			}
 
-			// Use first environment as default for releases, because in some cases we need to have the
-			// exact same environment in the release as in the catalog.
-			if len(tc.Params.Catalog.Releases.Items) > 0 &&
-				len(tc.Params.Catalog.Releases.Items[0].Releases) > 0 &&
-				tc.Params.Catalog.Releases.Items[0].Releases[0].Environment == nil &&
-				len(tc.Params.Catalog.Environments) > 0 {
-				tc.Params.Catalog.Releases.Items[0].Releases[0].Environment = tc.Params.Catalog.Environments[0]
-			}
-
-			err := Render(context.Background(), RenderParams{
-				Env:     tc.Params.Env,
-				Release: tc.Params.Release,
-				Cache: helm.ChartCache{
-					Refs: map[string]helm.Chart{
-						"generic": {
-							RepoURL: "default",
-							Name:    "chart",
-							Version: "v1",
-						},
-					},
-					DefaultChartRef: tc.Params.DefaultChart,
-					Root:            tc.Params.CacheDir,
-					Puller:          helmMock,
+			fsMock := &xfs.FSMock{
+				DirNameFunc: func() string {
+					return "path/to/chart"
 				},
-				Catalog:            tc.Params.Catalog,
-				CommonRenderParams: CommonRenderParams{ValueMapping: tc.Params.ValueMapping, IO: io, Helm: helmMock, Color: false},
+				ReadFileFunc: func(name string) ([]byte, error) {
+					return nil, os.ErrNotExist
+				},
+			}
+			if setup := tc.Params.ChartFS; setup != nil {
+				defer setup(fsMock)(t)
+			}
+
+			defer func() {
+				if err := recover(); err != nil {
+					require.NoError(t, fmt.Errorf("%v", err))
+				}
+			}()
+
+			result, err := Render(context.Background(), RenderParams{
+				Release: tc.Params.Release,
+				Chart: &helm.ChartFS{
+					FS: fsMock,
+				},
+				ValueMapping: tc.Params.ValueMapping,
+				Helm:         helmMock,
 			})
+
 			if tc.ExpectedError != "" {
 				require.EqualError(t, err, tc.ExpectedError)
 				return
 			}
-			require.NoError(t, err)
 
-			if tc.ExpectedOut != "" {
-				require.Equal(t, tc.ExpectedOut, stdout.String())
-			}
+			require.NoError(t, err)
+			require.Equal(t, tc.ExpectedOut, result)
 		})
 	}
 }

--- a/internal/release/validate/validate.go
+++ b/internal/release/validate/validate.go
@@ -4,14 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
-	"strings"
 
 	"github.com/davidmdm/x/xerr"
 	"golang.org/x/mod/semver"
 
 	"github.com/nestoca/joy/api/v1alpha1"
-	"github.com/nestoca/joy/internal"
 	"github.com/nestoca/joy/internal/config"
 	"github.com/nestoca/joy/internal/release/render"
 	"github.com/nestoca/joy/internal/yml"
@@ -67,21 +64,14 @@ func ValidateRelease(ctx context.Context, params ValidateReleaseParams) error {
 		return errors.New("contains locked TODO")
 	}
 
-	renderOpts := render.RenderReleaseParams{
-		Release: params.Release,
-		Chart:   params.Chart,
-		CommonRenderParams: render.CommonRenderParams{
-			ValueMapping: params.ValueMapping,
-			IO: internal.IO{
-				Out: io.Discard,
-				Err: io.Discard,
-				In:  io.NopCloser(strings.NewReader("")),
-			},
-			Helm: params.Helm,
-		},
+	renderOpts := render.RenderParams{
+		Release:      params.Release,
+		Chart:        params.Chart,
+		ValueMapping: params.ValueMapping,
+		Helm:         params.Helm,
 	}
 
-	if err := render.RenderRelease(ctx, renderOpts); err != nil {
+	if _, err := render.Render(ctx, renderOpts); err != nil {
 		return err
 	}
 

--- a/internal/release/validate/validate_test.go
+++ b/internal/release/validate/validate_test.go
@@ -76,7 +76,7 @@ func TestValidateRelease(t *testing.T) {
 					return "", errors.New("failed to render")
 				}
 			},
-			ExpectedErr: "rendering chart: failed to render",
+			ExpectedErr: "failed to render",
 		},
 		{
 			Name:    "no schema and render fails",
@@ -89,7 +89,8 @@ func TestValidateRelease(t *testing.T) {
 				mock.RenderFunc = func(ctx context.Context, opts helm.RenderOpts) (string, error) {
 					return "", errors.New("failed to render")
 				}
-			}, ExpectedErr: "rendering chart: failed to render",
+			},
+			ExpectedErr: "failed to render",
 		},
 		{
 			Name:    "fail to read schema",

--- a/internal/release/validate/validate_test.go
+++ b/internal/release/validate/validate_test.go
@@ -72,8 +72,8 @@ func TestValidateRelease(t *testing.T) {
 			},
 
 			HelmSetup: func(mock *helm.PullRendererMock) {
-				mock.RenderFunc = func(ctx context.Context, opts helm.RenderOpts) error {
-					return errors.New("failed to render")
+				mock.RenderFunc = func(ctx context.Context, opts helm.RenderOpts) (string, error) {
+					return "", errors.New("failed to render")
 				}
 			},
 			ExpectedErr: "rendering chart: failed to render",
@@ -86,8 +86,8 @@ func TestValidateRelease(t *testing.T) {
 				DirNameFunc:  func() string { return "" },
 			},
 			HelmSetup: func(mock *helm.PullRendererMock) {
-				mock.RenderFunc = func(ctx context.Context, opts helm.RenderOpts) error {
-					return errors.New("failed to render")
+				mock.RenderFunc = func(ctx context.Context, opts helm.RenderOpts) (string, error) {
+					return "", errors.New("failed to render")
 				}
 			}, ExpectedErr: "rendering chart: failed to render",
 		},

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -133,9 +133,9 @@ func Load(dir string, validChartRefs []string) (*Catalog, error) {
 	return c, nil
 }
 
-func (c *Catalog) WithReleaseFilter(filter filtering.Filter) *Catalog {
+func (c *Catalog) WithReleaseFilter(filter filtering.Filter) {
 	if filter == nil {
-		return c
+		return
 	}
 
 	releases := c.Releases.Items
@@ -152,13 +152,11 @@ func (c *Catalog) WithReleaseFilter(filter filtering.Filter) *Catalog {
 		}
 		c.Releases.Items = append(c.Releases.Items, cross)
 	}
-
-	return c
 }
 
-func (c *Catalog) WithReleases(names []string) *Catalog {
+func (c *Catalog) WithReleases(names []string) {
 	if len(names) == 0 {
-		return c
+		return
 	}
 
 	releases := c.Releases.Items
@@ -169,13 +167,11 @@ func (c *Catalog) WithReleases(names []string) *Catalog {
 			c.Releases.Items = append(c.Releases.Items, cross)
 		}
 	}
-
-	return c
 }
 
-func (c *Catalog) WithEnvironments(names []string) *Catalog {
+func (c *Catalog) WithEnvironments(names []string) {
 	if len(names) == 0 {
-		return c
+		return
 	}
 
 	allEnvs := c.Environments
@@ -201,8 +197,6 @@ func (c *Catalog) WithEnvironments(names []string) *Catalog {
 			}
 		}
 	}
-
-	return c
 }
 
 func (c *Catalog) ResolveRefs() error {

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -156,6 +156,23 @@ func (c *Catalog) WithReleaseFilter(filter filtering.Filter) *Catalog {
 	return c
 }
 
+func (c *Catalog) WithReleases(names []string) *Catalog {
+	if len(names) == 0 {
+		return c
+	}
+
+	releases := c.Releases.Items
+	c.Releases.Items = []*cross.Release{}
+
+	for _, cross := range releases {
+		if slices.Contains(names, cross.Name) {
+			c.Releases.Items = append(c.Releases.Items, cross)
+		}
+	}
+
+	return c
+}
+
 func (c *Catalog) WithEnvironments(names []string) *Catalog {
 	if len(names) == 0 {
 		return c
@@ -305,6 +322,26 @@ func (c *Catalog) loadProjects() ([]*v1alpha1.Project, error) {
 	})
 
 	return projects, nil
+}
+
+func (c *Catalog) GetReleaseNames() []string {
+	result := []string{}
+	for _, cross := range c.Releases.Items {
+		if slices.ContainsFunc(cross.Releases, func(release *v1alpha1.Release) bool {
+			return release != nil
+		}) {
+			result = append(result, cross.Name)
+		}
+	}
+	return result
+}
+
+func (c *Catalog) GetEnvironmentNames() []string {
+	result := []string{}
+	for _, env := range c.Environments {
+		result = append(result, env.Name)
+	}
+	return result
 }
 
 type catalogKey struct{}

--- a/pkg/helm/pull_renderer_mock.go
+++ b/pkg/helm/pull_renderer_mock.go
@@ -4,7 +4,7 @@
 package helm
 
 import (
-	context "context"
+	"context"
 	"sync"
 )
 
@@ -21,7 +21,7 @@ var _ PullRenderer = &PullRendererMock{}
 //			PullFunc: func(contextMoqParam context.Context, pullOptions PullOptions) error {
 //				panic("mock out the Pull method")
 //			},
-//			RenderFunc: func(ctx context.Context, opts RenderOpts) error {
+//			RenderFunc: func(ctx context.Context, opts RenderOpts) (string, error) {
 //				panic("mock out the Render method")
 //			},
 //		}
@@ -35,7 +35,7 @@ type PullRendererMock struct {
 	PullFunc func(contextMoqParam context.Context, pullOptions PullOptions) error
 
 	// RenderFunc mocks the Render method.
-	RenderFunc func(ctx context.Context, opts RenderOpts) error
+	RenderFunc func(ctx context.Context, opts RenderOpts) (string, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -98,7 +98,7 @@ func (mock *PullRendererMock) PullCalls() []struct {
 }
 
 // Render calls RenderFunc.
-func (mock *PullRendererMock) Render(ctx context.Context, opts RenderOpts) error {
+func (mock *PullRendererMock) Render(ctx context.Context, opts RenderOpts) (string, error) {
 	callInfo := struct {
 		Ctx  context.Context
 		Opts RenderOpts
@@ -111,9 +111,10 @@ func (mock *PullRendererMock) Render(ctx context.Context, opts RenderOpts) error
 	mock.lockRender.Unlock()
 	if mock.RenderFunc == nil {
 		var (
+			sOut   string
 			errOut error
 		)
-		return errOut
+		return sOut, errOut
 	}
 	return mock.RenderFunc(ctx, opts)
 }


### PR DESCRIPTION
- **feat(PL-2736): joy release render support all and all-env flags**
- **fix(PL-2736): include both git-ref and diff-ref catalog in known state**

With this PR we will be able to view the diff of the entire catalog's releases rendered via one command:
```
joy release render --all-envs --all --diff-ref REF
```
