### PR TITLE
fix(PL-660): stricter crd decoding

### DIFF
--- a/api/v1alpha1/environment.go
+++ b/api/v1alpha1/environment.go
@@ -6,7 +6,6 @@ import (
 	"slices"
 
 	"github.com/davidmdm/x/xerr"
-	"gopkg.in/yaml.v3"
 
 	"github.com/nestoca/joy/internal/yml"
 )
@@ -97,7 +96,7 @@ func IsValidEnvironment(apiVersion, kind string) bool {
 // NewEnvironment creates a new environment from given yaml file.
 func NewEnvironment(file *yml.File) (*Environment, error) {
 	var env Environment
-	if err := yaml.Unmarshal(file.Yaml, &env); err != nil {
+	if err := yml.UnmarshalStrict(file.Yaml, &env); err != nil {
 		return nil, fmt.Errorf("unmarshalling environment: %w", err)
 	}
 	env.File = file

--- a/api/v1alpha1/project.go
+++ b/api/v1alpha1/project.go
@@ -3,8 +3,6 @@ package v1alpha1
 import (
 	"fmt"
 
-	"gopkg.in/yaml.v3"
-
 	"github.com/nestoca/joy/internal/yml"
 )
 
@@ -71,7 +69,7 @@ func IsValidProject(apiVersion, kind string) bool {
 // NewProject creates a new project from given yaml file.
 func NewProject(file *yml.File) (*Project, error) {
 	var proj Project
-	if err := yaml.Unmarshal(file.Yaml, &proj); err != nil {
+	if err := yml.UnmarshalStrict(file.Yaml, &proj); err != nil {
 		return nil, fmt.Errorf("unmarshalling project: %w", err)
 	}
 	proj.File = file

--- a/api/v1alpha1/release.go
+++ b/api/v1alpha1/release.go
@@ -98,7 +98,7 @@ func IsValidRelease(apiVersion, kind string) bool {
 // LoadRelease loads a release from the given release file.
 func LoadRelease(file *yml.File) (*Release, error) {
 	var rel Release
-	if err := yaml.Unmarshal(file.Yaml, &rel); err != nil {
+	if err := yml.UnmarshalStrict(file.Yaml, &rel); err != nil {
 		return nil, fmt.Errorf("unmarshalling release: %w", err)
 	}
 	rel.File = file

--- a/internal/yml/decoder.go
+++ b/internal/yml/decoder.go
@@ -1,0 +1,13 @@
+package yml
+
+import (
+	"bytes"
+
+	"gopkg.in/yaml.v3"
+)
+
+func UnmarshalStrict(data []byte, ptr any) error {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	return decoder.Decode(ptr)
+}

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -26,6 +26,11 @@ func TestCatalogLoadE2E(t *testing.T) {
 			Folder: "broken-chart-ref-release",
 			Error:  "validating releases: test-release/testing: invalid chart: unknown ref: missing-ref",
 		},
+		{
+			Name:   "invalid crd schema",
+			Folder: "invalid-crd-schema",
+			Error:  "unmarshalling project: yaml: unmarshal errors:\n  line 6: field unknown-key not found in type v1alpha1.ProjectSpe",
+		},
 	}
 
 	for _, tc := range cases {
@@ -35,7 +40,8 @@ func TestCatalogLoadE2E(t *testing.T) {
 			require.NoError(t, err)
 
 			_, err = Load(filepath.Join("testdata", tc.Folder), cfg.KnownChartRefs())
-			require.EqualError(t, err, tc.Error)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.Error)
 		})
 	}
 }

--- a/pkg/catalog/testdata/invalid-crd-schema/joy.yaml
+++ b/pkg/catalog/testdata/invalid-crd-schema/joy.yaml
@@ -1,0 +1,20 @@
+minVersion: v0.32.1
+
+charts:
+  generic:
+    repoUrl: test
+    name: test
+    version: 0.0.0
+
+defaultChartRef: generic
+
+referenceEnvironment: testing
+
+valueMapping:
+  mappings:
+    image.tag: '{{ .Release.Spec.Version }}'
+    common.annotations.nesto\.ca/deployed-by: joy
+
+gitHubOrganization: nestoca
+
+defaultGitTagTemplate: api/v{{ .Release.Spec.Version }}

--- a/pkg/catalog/testdata/invalid-crd-schema/projects/testing.yaml
+++ b/pkg/catalog/testdata/invalid-crd-schema/projects/testing.yaml
@@ -1,0 +1,8 @@
+apiVersion: joy.nesto.ca/v1alpha1
+kind: Project
+metadata:
+  name: testing
+spec:
+  unknown-key: should not pass strict decoding
+  owners:
+    - stream-platform


### PR DESCRIPTION
We should use strict decoding of yaml documents when parsing catalog CRD-Like objects. This way if users add unknown properties such as typos, they can be caught early.

In the current catalog many projects have the typo `repositorySubPaths` instead of the expected `repositorySubpaths`, not `Paths` instead of `paths`.

This means that for some projects the git diff and git log commands do not work as expected.