### PR TITLE
feat(PL-2604): add ConfigChanges to ReleaseInfo

### DIFF
--- a/internal/ignore/ignore.go
+++ b/internal/ignore/ignore.go
@@ -9,8 +9,10 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
 )
 
-const commentPrefix = "#"
-const ignoreFileName = ".joyignore"
+const (
+	commentPrefix  = "#"
+	ignoreFileName = ".joyignore"
+)
 
 type Matcher struct {
 	giMatcher gitignore.Matcher

--- a/internal/release/promote/perform.go
+++ b/internal/release/promote/perform.go
@@ -71,7 +71,7 @@ func (p *Promotion) perform(opts PerformOpts) (string, error) {
 		}
 
 		p.printf("🧬 Collecting information about release %s...\n", style.Resource(crossRelease.Name))
-		releaseInfo, err := getReleaseInfo(sourceRelease, targetRelease, opts)
+		releaseInfo, err := getReleaseInfo(crossRelease, sourceRelease, targetRelease, opts)
 		if err != nil {
 			err = fmt.Errorf("collecting release %q info: %w", sourceRelease.Name, err)
 			p.printf("⚠️ %v\n", err)

--- a/internal/release/promote/promotion.go
+++ b/internal/release/promote/promotion.go
@@ -211,13 +211,13 @@ loop:
 			performParams.draft = true
 			break loop
 		case ViewGitLog:
-			for _, item := range selectedList.Items {
-				p.println(style.SecondaryInfo("--- " + item.Name))
-				source, target := at(item.Releases, sourceEnvIndex), at(item.Releases, targetEnvIndex)
+			for _, crossRelease := range selectedList.Items {
+				p.println(style.SecondaryInfo("--- " + crossRelease.Name))
+				source, target := at(crossRelease.Releases, sourceEnvIndex), at(crossRelease.Releases, targetEnvIndex)
 
-				info, err := getReleaseInfo(source, target, performParams)
+				info, err := getReleaseInfo(crossRelease, source, target, performParams)
 				if err != nil {
-					p.printf("error getting release information %s: %v\n", item.Name, err)
+					p.printf("error getting release information %s: %v\n", crossRelease.Name, err)
 					continue
 				}
 


### PR DESCRIPTION
This PR adds a new field to the ReleaseInfo struct "ValuesChanged".

This will allow users to highlight which releases contain configuration changes in the PR body.
