### PR TITLE
fix(PL-660): validate crd schemas against file content not deserialized representation

### DIFF
--- a/api/v1alpha1/environment.go
+++ b/api/v1alpha1/environment.go
@@ -88,7 +88,7 @@ func (e Environment) Validate(validChartRefs []string) error {
 		}
 	}
 	return xerr.MultiErrOrderedFrom("",
-		internal.ValidateAgainstSchema(schemas.Environment, e),
+		internal.ValidateAgainstSchema(schemas.Environment, e.File.Tree),
 		xerr.MultiErrOrderedFrom("validating chart references", errs...),
 	)
 }

--- a/api/v1alpha1/project.go
+++ b/api/v1alpha1/project.go
@@ -64,7 +64,7 @@ type Project struct {
 }
 
 func (project *Project) Validate() error {
-	return internal.ValidateAgainstSchema(schemas.Project, project)
+	return internal.ValidateAgainstSchema(schemas.Project, project.File.Tree)
 }
 
 func IsValidProject(apiVersion, kind string) bool {

--- a/api/v1alpha1/release.go
+++ b/api/v1alpha1/release.go
@@ -88,7 +88,7 @@ type Release struct {
 }
 
 func (release Release) Validate() error {
-	return internal.ValidateAgainstSchema(schemas.Release, release)
+	return internal.ValidateAgainstSchema(schemas.Release, release.File.Tree)
 }
 
 func (release *Release) UnmarshalYAML(node *yaml.Node) error {

--- a/internal/schema.go
+++ b/internal/schema.go
@@ -1,11 +1,12 @@
 package internal
 
 import (
-	"encoding/json"
+	"fmt"
 
 	"cuelang.org/go/cue"
 	cueerrors "cuelang.org/go/cue/errors"
 	"cuelang.org/go/cue/format"
+	"gopkg.in/yaml.v3"
 
 	"github.com/davidmdm/x/xerr"
 )
@@ -24,18 +25,15 @@ func StringifySchema(value cue.Value) string {
 	return string(out)
 }
 
-func ValidateAgainstSchema(schema cue.Value, value any) error {
-	data, err := json.Marshal(value)
-	if err != nil {
+func ValidateAgainstSchema(schema cue.Value, node *yaml.Node) error {
+	var value any
+	if err := node.Decode(&value); err != nil {
 		return err
 	}
 
-	var generic any
-	if err := json.Unmarshal(data, &generic); err != nil {
-		return err
-	}
+	value = JsonCompat(value)
 
-	baseValue := schema.Context().Encode(generic)
+	baseValue := schema.Context().Encode(value)
 	if err := schema.Unify(baseValue).Validate(cue.Final(), cue.Concrete(true)); err != nil {
 		var errs []error
 		for _, e := range cueerrors.Errors(err) {
@@ -45,4 +43,31 @@ func ValidateAgainstSchema(schema cue.Value, value any) error {
 	}
 
 	return nil
+}
+
+// JsonCompat takes a generic as returned from yaml.Unmarshal and returns a new instance with all map[any]any converted to map[string]any
+// for compatiblilty with Apis that only support JSON generic objects. (Objects marshalled from json only support string keys).
+func JsonCompat(value any) any {
+	switch value := value.(type) {
+	case []any:
+		copy := make([]any, len(value))
+		for i, elem := range value {
+			copy[i] = JsonCompat(elem)
+		}
+		return copy
+	case map[string]any:
+		copy := make(map[string]any, len(value))
+		for k, v := range value {
+			copy[k] = JsonCompat(v)
+		}
+		return copy
+	case map[any]any:
+		copy := make(map[string]any, len(value))
+		for k, v := range value {
+			copy[fmt.Sprint(k)] = JsonCompat(v)
+		}
+		return copy
+	default:
+		return value
+	}
 }

--- a/internal/schema_test.go
+++ b/internal/schema_test.go
@@ -6,6 +6,7 @@ import (
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestValidateAgainstSchema(t *testing.T) {
@@ -24,13 +25,16 @@ func TestValidateAgainstSchema(t *testing.T) {
 			Name:   "is invalid",
 			Schema: cuecontext.New().CompileString(`string`),
 			Input:  3.14159265,
-      Err:    "error: conflicting values string and 3.14159265 (mismatched types string and float)",
+			Err:    "error: conflicting values string and 3.14159265 (mismatched types string and float)",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			err := ValidateAgainstSchema(tc.Schema, tc.Input)
+			var node yaml.Node
+			require.NoError(t, node.Encode(tc.Input))
+
+			err := ValidateAgainstSchema(tc.Schema, &node)
 			if tc.Err == "" {
 				require.NoError(t, err)
 				return


### PR DESCRIPTION
Not too long ago, schemas were added to represent the Joy CRDs. However the original implementation was wrong in that it would validate against the already serialized Go struct instead of the files root yaml node.

This would cause information loss and things to not get picked up by the schema validation.

For example with this change the internal tests started failing because `versionKey` which is an unknown property was being caught and it previously was not.

```
loading catalog: validating releases:
  - podinfo/demo: validation: error: #release.spec.versionKey: field not allowed
  - podinfo/dev: validation: error: #release.spec.versionKey: field not allowed
  - podinfo/platform: validation: error: #release.spec.versionKey: field not allowed
  - podinfo/qa: validation: error: #release.spec.versionKey: field not allowed
```

This has since been fixed in this [commit](https://github.com/nestoca/catalog/commit/b7647df02518961dcc3788b0366b4006160826ba).