### PR TITLE
feat(PL-2834): support mappings per chart and release

### DIFF
--- a/api/v1alpha1/release.go
+++ b/api/v1alpha1/release.go
@@ -25,10 +25,11 @@ type ReleaseMetadata struct {
 }
 
 type ReleaseChart struct {
-	Ref     string `yaml:"ref,omitempty" json:"ref,omitempty"`
-	Version string `yaml:"version,omitempty" json:"version,omitempty"`
-	Name    string `yaml:"name,omitempty" json:"name,omitempty"`
-	RepoUrl string `yaml:"repoUrl,omitempty" json:"repoUrl,omitempty"`
+	Ref      string         `yaml:"ref,omitempty" json:"ref,omitempty"`
+	Version  string         `yaml:"version,omitempty" json:"version,omitempty"`
+	Name     string         `yaml:"name,omitempty" json:"name,omitempty"`
+	RepoUrl  string         `yaml:"repoUrl,omitempty" json:"repoUrl,omitempty"`
+	Mappings map[string]any `yaml:"mappings,omitempty" json:"mappings,omitempty"`
 }
 
 func (chart ReleaseChart) Validate(validRefs []string) error {

--- a/internal/release/render/render.go
+++ b/internal/release/render/render.go
@@ -128,6 +128,10 @@ func HydrateValues(release *v1alpha1.Release, chart *helm.ChartFS, mappings *con
 		return nil, fmt.Errorf("hydrating object values: %w", err)
 	}
 
+	for key, value := range chart.Mappings {
+		setInMap(values, splitIntoPathSegments(key), value)
+	}
+
 	if mappings != nil && !slices.Contains(mappings.ReleaseIgnoreList, release.Name) {
 		for mapping, value := range mappings.Mappings {
 			setInMap(values, splitIntoPathSegments(mapping), value)


### PR DESCRIPTION
## Changes
This PR allows mappings to be configured per chart both at the reference level within the catalog's joy.yaml configuration and within the release.

This will allow us to move the `image.tag` mapping from the global configuration to being specific to the `generic` chart. It will allow us to map our application version to different mappings for different charts.

This feature replaces the intent of `versionKey` that was broken but used in the appset.