### PR TITLE
fix(PL-3111): use text/template

### DIFF
--- a/internal/info/provider_mock.go
+++ b/internal/info/provider_mock.go
@@ -4,8 +4,9 @@
 package info
 
 import (
-	v1alpha1 "github.com/nestoca/joy/api/v1alpha1"
 	"sync"
+
+	v1alpha1 "github.com/nestoca/joy/api/v1alpha1"
 )
 
 // Ensure, that ProviderMock does implement Provider.

--- a/internal/links/provider_mock.go
+++ b/internal/links/provider_mock.go
@@ -4,8 +4,9 @@
 package links
 
 import (
-	v1alpha1 "github.com/nestoca/joy/api/v1alpha1"
 	"sync"
+
+	v1alpha1 "github.com/nestoca/joy/api/v1alpha1"
 )
 
 // Ensure, that ProviderMock does implement Provider.

--- a/internal/release/promote/prompt_provider_mock.go
+++ b/internal/release/promote/prompt_provider_mock.go
@@ -4,10 +4,11 @@
 package promote
 
 import (
+	"sync"
+
 	"github.com/nestoca/joy/api/v1alpha1"
 	"github.com/nestoca/joy/internal/release/cross"
 	"github.com/nestoca/joy/internal/yml"
-	"sync"
 )
 
 // Ensure, that PromptProviderMock does implement PromptProvider.

--- a/internal/release/render/render.go
+++ b/internal/release/render/render.go
@@ -5,10 +5,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"html/template"
 	"os"
 	"regexp"
 	"strings"
+	"text/template"
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
@@ -16,8 +16,9 @@ import (
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/davidmdm/x/xerr"
-	"github.com/nestoca/survey/v2"
 	"gopkg.in/yaml.v3"
+
+	"github.com/nestoca/survey/v2"
 
 	"github.com/nestoca/joy/api/v1alpha1"
 	"github.com/nestoca/joy/internal/environment"

--- a/internal/release/render/render_test.go
+++ b/internal/release/render/render_test.go
@@ -573,6 +573,14 @@ func TestSchemaUnification(t *testing.T) {
 			Values:         map[string]any{"color": "red"},
 			ExpectedValues: map[string]any{"color": "red"},
 		},
+		{
+			Name: "do not html escape strings",
+			ReadFileFunc: func(name string) ([]byte, error) {
+				return nil, os.ErrNotExist
+			},
+			Values:         map[string]any{"successCondition": "x > 100"},
+			ExpectedValues: map[string]any{"successCondition": "x > 100"},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION

When hydrating yaml we were using the `html/template` which escapes strings to be compliant with HTML. This messes up the `successCondition` here: https://github.com/nestoca/catalog/commit/0955b70944217a91c50acffcc21994f1973daafe#diff-91aa1f4b1ecdb0c810eed73d84a3f0657a423783212cfa7db6df3c2ab4d04882R91