### PR TITLE
feat(PL-4155): remove redundant default value help text

### DIFF
--- a/internal/formatting/formatting.go
+++ b/internal/formatting/formatting.go
@@ -41,5 +41,5 @@ func RenderNames[T Named](writer io.Writer, items []T) error {
 
 // AddFormatFlag registers --format / -f for render format (table, json, yaml, names).
 func AddFormatFlag(cmd *cobra.Command, format *Format) {
-	cmd.Flags().StringVarP((*string)(format), "format", "f", string(FormatTable), "format (table, json, yaml, names; defaults to table)")
+	cmd.Flags().StringVarP((*string)(format), "format", "f", string(FormatTable), "output format, one of: table, json, yaml, names")
 }


### PR DESCRIPTION
Current help text for `--format` shows redundant default value:
```
  -f, --format string      format (table, json, yaml, names; defaults to table) (default "table")
```