### PR TITLE
fix(PL-5476): handle empty output from gh label list --json

### DIFF
--- a/internal/github/pull_request_provider.go
+++ b/internal/github/pull_request_provider.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os/exec"
@@ -214,9 +215,14 @@ func (p *PullRequestProvider) createLabels(labels ...string) error {
 		return fmt.Errorf("listing labels: %s", output)
 	}
 
+	// `gh label list --json` returns empty output when the repo has no labels,
+	// which is not valid JSON and would fail to unmarshal.
+	output = bytes.TrimSpace(output)
 	var existingLabels []label
-	if err := json.Unmarshal(output, &existingLabels); err != nil {
-		return fmt.Errorf("unmarshaling label list: %w", err)
+	if len(output) > 0 {
+		if err := json.Unmarshal(output, &existingLabels); err != nil {
+			return fmt.Errorf("unmarshaling label list: %w", err)
+		}
 	}
 	existingLabelSet := make(map[string]bool)
 	for _, existingLabel := range existingLabels {


### PR DESCRIPTION
# Description & Business motivation

As reported by @adrian.garcia in https://nestoca.atlassian.net/wiki/spaces/DEVOPS/pages/3277291535/Tool+Joy, when calling joy pr promote on a report with absolutely no labels defined gives that error:

```
setting promotion for branch your-branch-name pull request to "staging" environment: adding label staging to branch your-branch-name: unmarshaling label list: unexpected end of JSON input
```

That’s because `gh label list --json ...` returns an empty output when there are no labels defined in the repo, which is invalid JSON.