### PR TITLE
chore(PL-4696): bump Go toolchain to go1.26.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/nestoca/joy
 
 go 1.26.0
+toolchain go1.26.3
 
 require (
 	cuelang.org/go v0.15.4


### PR DESCRIPTION
Bumps the Go toolchain directive to go1.26.3, resolving Snyk findings for stdlib packages which are fixed in newer Go toolchain versions.