### PR TITLE
fix(PL-4460): remove non-functional --releases flag from joy rel list

### DIFF
--- a/cmd/joy/release.go
+++ b/cmd/joy/release.go
@@ -63,7 +63,7 @@ func NewReleaseCmd(preRunConfigs PreRunConfigs) *cobra.Command {
 }
 
 func NewReleaseListCmd(preRunConfigs PreRunConfigs) *cobra.Command {
-	var releases, commaSeparatedEnvs, owners string
+	var commaSeparatedEnvs, owners string
 	var narrow, wide bool
 	var format formatting.Format
 	var onlySelection, ignoreSelection bool
@@ -95,10 +95,6 @@ func NewReleaseListCmd(preRunConfigs PreRunConfigs) *cobra.Command {
 				return cfg.Environments.Selected
 			}()
 
-			if releases != "" {
-				return fmt.Errorf("--releases flag no longer supported, please specify comma-delimited list of releases as first positional argument")
-			}
-
 			// Filter releases
 			if len(args) > 0 {
 				releasePattern := args[0]
@@ -123,7 +119,6 @@ func NewReleaseListCmd(preRunConfigs PreRunConfigs) *cobra.Command {
 			return list.Render(cmd.OutOrStdout(), cat.Dir, releaseList, format, cfg.ColumnWidths.Get(narrow, wide))
 		},
 	}
-	cmd.Flags().StringVarP(&releases, "releases", "r", "", "Releases to list (comma-separated, defaults to configured selection or all)")
 	cmd.Flags().StringVarP(&commaSeparatedEnvs, "env", "e", "", "environments to list (comma-separated, defaults to configured selection or all)")
 	cmd.Flags().StringVarP(&owners, "owners", "o", "", "List releases by owners (comma-separated, defaults to all)")
 	cmd.Flags().BoolVarP(&narrow, "narrow", "n", false, "Use narrow columns mode")


### PR DESCRIPTION
## What

Removes the \`--releases\` / \`-r\` flag from \`joy rel list\`. The flag variable, its registration, and the dead error-check that fired when it was used are all deleted.

## Why

In [#143 (PL-2602)](https://github.com/nestoca/joy/pull/143) the \`--releases\` flag was superseded by a positional comma-separated release pattern argument. At that point the flag was wired to immediately return an error, but was never removed from the command — leaving it visible in \`--help\` while being completely non-functional.

## Test Plan

- [x] \`go build ./...\` passes cleanly
- [x] \`joy rel list --help\` no longer shows \`--releases\` or \`-r\`
- [x] Verified the positional argument path (\`joy rel list my-release\`) is untouched

## References

- [PL-4460](https://nestoca.atlassian.net/browse/PL-4460)
- [#143 (PL-2602)](https://github.com/nestoca/joy/pull/143) — original PR that superseded the flag

[PL-4460]: https://nestoca.atlassian.net/browse/PL-4460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ