### PR TITLE
fix(ci): update github workflows

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -76,8 +76,9 @@ jobs:
       - name: Dispatch workflow
         env:
           GH_TOKEN: ${{ steps.generate-joy-ci-triggerer-token.outputs.token }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          gh workflow run --repo github.com/nestoca/catalog -f ref=${{ github.head_ref }} .github/workflows/joy-test.yaml
+          gh workflow run --repo github.com/nestoca/catalog -f ref="$HEAD_REF" .github/workflows/joy-test.yaml
           sleep 5s
           workflowId=$(gh run ls --repo github.com/nestoca/catalog --workflow joy-test --json databaseId -q '.[0].databaseId')
           gh run watch --exit-status --repo github.com/nestoca/catalog $workflowId
@@ -114,7 +115,7 @@ jobs:
 
       - name: Generate changelog and tag release
         id: changelog
-        uses: nestoca/conventional-changelog-action@releases/v4
+        uses: nestoca/conventional-changelog-action@a27a4debeb9e6b0ff100a3a4c5ff9a5926587608 # releases/v4
         with:
           preset: conventionalcommits # default is `angular` and does not support breaking changes of type feat!
           input-file: CHANGELOG.md


### PR DESCRIPTION
## What

- Fix script injection: move `github.head_ref` out of inline script interpolation into an env var (`HEAD_REF`)
- Quote the env var usage (`"$HEAD_REF"`) to prevent word splitting
- Pin `nestoca/conventional-changelog-action` to a commit SHA instead of a mutable branch ref (`releases/v4`)

## Why
Two findings from `poutine analyze_local .`:
- **warning** `injection`: `${{ github.head_ref }}` was interpolated directly into a shell script, allowing a malicious branch name to inject arbitrary shell commands
- **note** `github_action_from_unverified_creator_used`: action was pinned to a mutable branch ref; SHA pinning reduces supply chain risk

## How
Fixed with Claude Code

- `poutine analyze_local .` → identified findings → applied fixes → verified clean run for the injection finding

## Test Plan
- [x] Run `poutine analyze_local .` — injection finding is resolved
- [ ] Confirm the `publish` job still works on merge to master (changelog action pinned to same commit it was previously tracking)