### PR TITLE
fix(PL-6101): use upstream TriPSs/conventional-changelog-action

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Generate changelog and tag release
         id: changelog
-        uses: nestoca/conventional-changelog-action@a27a4debeb9e6b0ff100a3a4c5ff9a5926587608 # releases/v4
+        uses: TriPSs/conventional-changelog-action@3c4970b6573374889b897403d2f1278c395ea0df # releases/v5
         with:
           preset: conventionalcommits # default is `angular` and does not support breaking changes of type feat!
           input-file: CHANGELOG.md


### PR DESCRIPTION
## What

Switch from `nestoca/conventional-changelog-action` to `TriPSs/conventional-changelog-action@3c4970b6 # releases/v5` (upstream).

## Why

Maintaining the nestoca fork is unnecessary overhead. Pinning an action to a specific upstream commit SHA gives the same supply-chain guarantee as maintaining a fork — making the fork unnecessary. We're dropping the fork in favour of pinning directly to the upstream release branch.

## References

- [PL-6101](https://nestoca.atlassian.net/browse/PL-6101) — Switch back to TriPSs/conventional-changelog-action from nestoca fork
- [PL-5691](https://nestoca.atlassian.net/browse/PL-5691) — Original Snyk/security ticket
- Slack: https://nestomortgage.slack.com/archives/C02RCBVTJ3G/p1780940095066939

[PL-6101]: https://nestoca.atlassian.net/browse/PL-6101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PL-5691]: https://nestoca.atlassian.net/browse/PL-5691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI dependency swap with the same step configuration; release behavior could differ only if v5 outputs differ from the fork, but scope is limited to changelog generation on master.
> 
> **Overview**
> The **publish** job in `build-test.yaml` now runs **TriPSs/conventional-changelog-action** at commit `3c4970b6` (`releases/v5`) instead of the **nestoca** fork that pointed at `releases/v4`.
> 
> All **with:** inputs for the “Generate changelog and tag release” step are unchanged; only the action source and pinned SHA differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5cfac66fb09b530f193692b8c70287f3fe719e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->