### PR TITLE
fix(PL-6199): guard target release get related pull requests

### DIFF
--- a/internal/release/promote/pr_rendering.go
+++ b/internal/release/promote/pr_rendering.go
@@ -172,9 +172,11 @@ func getReleaseInfo(cross *cross.Release, sourceRelease, targetRelease *v1alpha1
 		})
 	}
 
-	releaseInfo.RelatedPullRequests, err = opts.infoProvider.GetRelatedPullRequests(targetRelease)
-	if err != nil {
-		return nil, fmt.Errorf("listing related pull requests for release %s: %w", sourceRelease.Name, err)
+	if targetRelease != nil {
+		releaseInfo.RelatedPullRequests, err = opts.infoProvider.GetRelatedPullRequests(targetRelease)
+		if err != nil {
+			return nil, fmt.Errorf("listing related pull requests for release %s: %w", sourceRelease.Name, err)
+		}
 	}
 	return &releaseInfo, nil
 }


### PR DESCRIPTION
Fixes the issue where getting related pull requests for a release that does yet exist in the target env during `release promotion` would segfault given that the target release is nil.

Here is a PR generated using the fixed CLI against a command that would previously segfault:

generated with the following command:
```sh
joy --skip-dev-check rel prom -s qa -t td-sit1 blueprint-gateway 

```
https://github.com/nestoca/catalog/pull/48873


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single nil guard around an existing API call; behavior unchanged when a target release is present.
> 
> **Overview**
> **`getReleaseInfo`** no longer calls **`GetRelatedPullRequests`** when there is no target release yet.
> 
> Promotion can run with a **nil** target when the release is being **created** in the target environment (`isCreatingTargetRelease` in `perform.go`). The related-PR step assumed a target release existed and could fail or misbehave because **`GetRelatedPullRequests`** reads paths and labels from that release. The lookup is now skipped in that case; **`RelatedPullRequests`** stays unset when there is no target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dd39cf50407072668af22b4e5aa787ddb73dfbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->