### PR TITLE
chore(PL-6131): add scheme to v1alpha1 package for quality of life

### DIFF
--- a/api/v1alpha1/scheme.go
+++ b/api/v1alpha1/scheme.go
@@ -1,0 +1,11 @@
+package v1alpha1
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+var SchemeGroupVersion = schema.GroupVersion{Group: "joy.nesto.ca", Version: "v1alpha1"}
+
+const (
+	KindRelease     = "Release"
+	KindEnvironment = "Environment"
+	KindProject     = "Project"
+)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> New constants file only; no behavior or call-site changes.
> 
> **Overview**
> Adds **`api/v1alpha1/scheme.go`** with shared Kubernetes-style metadata: **`SchemeGroupVersion`** (`joy.nesto.ca` / `v1alpha1`) and **`KindRelease`**, **`KindEnvironment`**, and **`KindProject`** constants.
> 
> This is additive only; existing per-type kind constants and hardcoded `apiVersion` checks in the resource files are unchanged in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8315203d6128c36683f269a0e55fde823e2e4291. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->