### PR TITLE
fix(PL-5471): preserve release info when commit metadata lookup fails

### DIFF
--- a/internal/release/promote/pr_rendering.go
+++ b/internal/release/promote/pr_rendering.go
@@ -152,7 +152,7 @@ func getReleaseInfo(cross *cross.Release, sourceRelease, targetRelease *v1alpha1
 	gitHubAuthors, err := opts.infoProvider.GetCommitsGitHubAuthors(project, olderTag, newerTag)
 	if err != nil {
 		releaseInfo.Error = fmt.Errorf("getting GitHub authors: %w", err)
-		return &releaseInfo, nil
+		gitHubAuthors = nil
 	}
 
 	releaseInfo.Reviewers = project.Spec.Reviewers

--- a/internal/release/promote/pr_rendering.go
+++ b/internal/release/promote/pr_rendering.go
@@ -145,12 +145,14 @@ func getReleaseInfo(cross *cross.Release, sourceRelease, targetRelease *v1alpha1
 
 	commitsMetadata, err := opts.infoProvider.GetCommitsMetadata(projectDir, olderTag, newerTag)
 	if err != nil {
-		return nil, fmt.Errorf("getting commits metadata: %w", err)
+		releaseInfo.Error = fmt.Errorf("getting commits metadata: %w", err)
+		return &releaseInfo, nil
 	}
 
 	gitHubAuthors, err := opts.infoProvider.GetCommitsGitHubAuthors(project, olderTag, newerTag)
 	if err != nil {
-		return nil, fmt.Errorf("getting GitHub authors: %w", err)
+		releaseInfo.Error = fmt.Errorf("getting GitHub authors: %w", err)
+		return &releaseInfo, nil
 	}
 
 	releaseInfo.Reviewers = project.Spec.Reviewers

--- a/internal/release/promote/pr_rendering_test.go
+++ b/internal/release/promote/pr_rendering_test.go
@@ -1,6 +1,7 @@
 package promote
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -125,6 +126,74 @@ func TestGetReleaseInfo(t *testing.T) {
 			Expectations: func(t *testing.T, releaseInfo *ReleaseInfo, err error) {
 				require.NoError(t, err)
 				require.True(t, releaseInfo.ValuesChanged)
+			},
+		},
+		{
+			Name:  "GetCommitsMetadata failure preserves version and tag fields",
+			Cross: &cross.Release{},
+			Source: &v1alpha1.Release{
+				Project: &v1alpha1.Project{},
+				Spec:    v1alpha1.ReleaseSpec{Version: "1.0.1"},
+			},
+			Target: &v1alpha1.Release{
+				Spec: v1alpha1.ReleaseSpec{Version: "1.0.0"},
+			},
+			Opts: PerformOpts{
+				infoProvider: &info.ProviderMock{
+					GetReleaseGitTagFunc: func(release *v1alpha1.Release) (string, error) {
+						return "api/v" + release.Spec.Version, nil
+					},
+					GetProjectSourceDirFunc: func(_ *v1alpha1.Project) (string, error) {
+						return "/some/dir", nil
+					},
+					GetCommitsMetadataFunc: func(_, _, _ string) ([]*info.CommitMetadata, error) {
+						return nil, errors.New("fatal: ambiguous argument 'api/v1.0.0..api/v1.0.1'")
+					},
+				},
+				linksProvider: new(links.ProviderMock),
+			},
+			Expectations: func(t *testing.T, releaseInfo *ReleaseInfo, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, releaseInfo)
+				require.Error(t, releaseInfo.Error)
+				require.Equal(t, "api/v1.0.1", releaseInfo.Source.GitTag)
+				require.Equal(t, "api/v1.0.0", releaseInfo.Target.GitTag)
+				require.Equal(t, "1.0.1", releaseInfo.Source.DisplayVersion)
+				require.Equal(t, "1.0.0", releaseInfo.Target.DisplayVersion)
+			},
+		},
+		{
+			Name:  "GetCommitsGitHubAuthors failure preserves version and tag fields",
+			Cross: &cross.Release{},
+			Source: &v1alpha1.Release{
+				Project: &v1alpha1.Project{},
+				Spec:    v1alpha1.ReleaseSpec{Version: "1.0.1"},
+			},
+			Target: &v1alpha1.Release{
+				Spec: v1alpha1.ReleaseSpec{Version: "1.0.0"},
+			},
+			Opts: PerformOpts{
+				infoProvider: &info.ProviderMock{
+					GetReleaseGitTagFunc: func(release *v1alpha1.Release) (string, error) {
+						return "api/v" + release.Spec.Version, nil
+					},
+					GetProjectSourceDirFunc: func(_ *v1alpha1.Project) (string, error) {
+						return "/some/dir", nil
+					},
+					GetCommitsGitHubAuthorsFunc: func(_ *v1alpha1.Project, _, _ string) (map[string]string, error) {
+						return nil, errors.New("getting commits GitHub authors: HTTP 422")
+					},
+				},
+				linksProvider: new(links.ProviderMock),
+			},
+			Expectations: func(t *testing.T, releaseInfo *ReleaseInfo, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, releaseInfo)
+				require.Error(t, releaseInfo.Error)
+				require.Equal(t, "api/v1.0.1", releaseInfo.Source.GitTag)
+				require.Equal(t, "api/v1.0.0", releaseInfo.Target.GitTag)
+				require.Equal(t, "1.0.1", releaseInfo.Source.DisplayVersion)
+				require.Equal(t, "1.0.0", releaseInfo.Target.DisplayVersion)
 			},
 		},
 	}

--- a/internal/release/promote/pr_rendering_test.go
+++ b/internal/release/promote/pr_rendering_test.go
@@ -163,7 +163,7 @@ func TestGetReleaseInfo(t *testing.T) {
 			},
 		},
 		{
-			Name:  "GetCommitsGitHubAuthors failure preserves version and tag fields",
+			Name:  "GetCommitsGitHubAuthors failure preserves version, tag, and commit list",
 			Cross: &cross.Release{},
 			Source: &v1alpha1.Release{
 				Project: &v1alpha1.Project{},
@@ -180,6 +180,11 @@ func TestGetReleaseInfo(t *testing.T) {
 					GetProjectSourceDirFunc: func(_ *v1alpha1.Project) (string, error) {
 						return "/some/dir", nil
 					},
+					GetCommitsMetadataFunc: func(_, _, _ string) ([]*info.CommitMetadata, error) {
+						return []*info.CommitMetadata{
+							{Sha: "abc1234", Author: "Alice", Message: "feat: add thing"},
+						}, nil
+					},
 					GetCommitsGitHubAuthorsFunc: func(_ *v1alpha1.Project, _, _ string) (map[string]string, error) {
 						return nil, errors.New("getting commits GitHub authors: HTTP 422")
 					},
@@ -194,6 +199,10 @@ func TestGetReleaseInfo(t *testing.T) {
 				require.Equal(t, "api/v1.0.0", releaseInfo.Target.GitTag)
 				require.Equal(t, "1.0.1", releaseInfo.Source.DisplayVersion)
 				require.Equal(t, "1.0.0", releaseInfo.Target.DisplayVersion)
+				require.Len(t, releaseInfo.Commits, 1)
+				require.Equal(t, "abc1234", releaseInfo.Commits[0].Sha)
+				require.Equal(t, "Alice", releaseInfo.Commits[0].Author)
+				require.Empty(t, releaseInfo.Commits[0].GitHubAuthor)
 			},
 		},
 	}


### PR DESCRIPTION
## What

When `GetCommitsMetadata` or `GetCommitsGitHubAuthors` fail during `release promote`, the error now degrades gracefully instead of producing a malformed commit body.

## Why

Previously, these errors propagated up to `perform()`, which constructed a bare `ReleaseInfo` with all version and tag fields zeroed. The commit template would then render blank versions and a broken compare URL:

```
- Promote my-service  → 
  https://github.com/org/my-service/compare/...
```

`GetProjectSourceDir` failure was already handled gracefully (storing the error and returning the partial struct). This fix applies the same pattern to the two downstream calls so version/tag fields remain populated and the error is surfaced via the existing `# Rendering Errors:` footer.

## Test Plan

- Added two unit test cases to `TestGetReleaseInfo` covering both failure paths
- Confirmed both cases fail against the unfixed code and pass with the fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to promote PR message assembly with tests; no auth or data-path changes, only error-handling behavior for optional enrichment steps.
> 
> **Overview**
> **`getReleaseInfo`** no longer aborts promote PR rendering when commit history or GitHub author lookups fail. Failures on **`GetCommitsMetadata`** and **`GetCommitsGitHubAuthors`** now follow the same graceful path as **`GetProjectSourceDir`**: the error is stored on **`ReleaseInfo.Error`**, the function returns a populated struct (versions, git tags, compare range), and the promote message can still render with the existing **`# Rendering Errors:`** footer.
> 
> When author lookup fails but commit metadata succeeds, the change continues building the commit list with empty **`GitHubAuthor`** fields instead of dropping all release context.
> 
> Two **`TestGetReleaseInfo`** cases lock in both failure paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffd6227a066017a67f808f9ad9876fdd5bc73bd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->