### PR TITLE
feat(PL-6131): make Project CR operator compatible with apimachinery meta

### DIFF
--- a/api/v1alpha1/project.go
+++ b/api/v1alpha1/project.go
@@ -5,19 +5,13 @@ import (
 
 	"github.com/nestoca/joy/internal"
 	"github.com/nestoca/joy/internal/yml"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const ProjectKind = "Project"
 
 type ProjectMetadata struct {
-	// Name is the name of the project.
-	Name string `yaml:"name,omitempty" json:"name,omitempty"`
-
-	// Labels is the list of labels for the project.
-	Labels map[string]string `yaml:"labels,omitempty" json:"labels,omitempty"`
-
-	// Annotations is the list of annotations for the project.
-	Annotations map[string]string `yaml:"annotations,omitempty" json:"annotations,omitempty"`
+	metav1.ObjectMeta `yaml:",inline" json:"metadata"`
 
 	// RelativePath is the catalog-relative path to this resource's yaml file (set only for list JSON/YAML output).
 	RelativePath string `yaml:"relativePath,omitempty" json:"relativePath,omitempty"`

--- a/internal/links/provider_test.go
+++ b/internal/links/provider_test.go
@@ -78,9 +78,7 @@ func TestGetProjectLinks(t *testing.T) {
 	}
 
 	project := &v1alpha1.Project{
-		ProjectMetadata: v1alpha1.ProjectMetadata{
-			Name: "my-project",
-		},
+		ProjectMetadata: v1alpha1.ProjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: "my-project"}},
 	}
 
 	for _, tc := range cases {
@@ -161,9 +159,7 @@ func TestGetReleaseLinks(t *testing.T) {
 		EnvironmentMetadata: v1alpha1.EnvironmentMetadata{ObjectMeta: metav1.ObjectMeta{Name: "staging"}},
 	}
 	project := &v1alpha1.Project{
-		ProjectMetadata: v1alpha1.ProjectMetadata{
-			Name: "my-project",
-		},
+		ProjectMetadata: v1alpha1.ProjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: "my-project"}},
 	}
 	rel := &v1alpha1.Release{
 		ReleaseMetadata: v1alpha1.ReleaseMetadata{

--- a/internal/release/promote/test/promotion_test.go
+++ b/internal/release/promote/test/promotion_test.go
@@ -394,12 +394,8 @@ func newEnvironments() []*v1alpha1.Environment {
 }
 
 var dummyProject = &v1alpha1.Project{
-	ProjectMetadata: v1alpha1.ProjectMetadata{
-		Name: "project1",
-	},
-	Spec: v1alpha1.ProjectSpec{
-		Repository: "owner/project1",
-	},
+	ProjectMetadata: v1alpha1.ProjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: "project1"}},
+	Spec:            v1alpha1.ProjectSpec{Repository: "owner/project1"},
 }
 
 func newRelease(name, specYaml, envName string) *v1alpha1.Release {

--- a/pkg/catalog/builder.go
+++ b/pkg/catalog/builder.go
@@ -36,7 +36,7 @@ func (b *Builder) AddEnvironment(name string, f func(e *v1alpha1.Environment)) *
 
 func (b *Builder) AddProject(name string, f func(p *v1alpha1.Project)) *v1alpha1.Project {
 	project := v1alpha1.Project{
-		ProjectMetadata: v1alpha1.ProjectMetadata{Name: name},
+		ProjectMetadata: v1alpha1.ProjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: name}},
 	}
 	if f != nil {
 		f(&project)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the Project API shape and JSON/YAML metadata serialization; any external consumers or schemas expecting flat name/labels/annotations fields need to stay compatible with embedded `metadata`.
> 
> **Overview**
> **Project** metadata now embeds `metav1.ObjectMeta` (same pattern as **Environment** / **Release**), replacing hand-rolled `name`, `labels`, and `annotations` fields so the Project CR matches Kubernetes apimachinery expectations for operator/controller tooling.
> 
> Call sites that constructed `ProjectMetadata` literals were updated to set `ObjectMeta: metav1.ObjectMeta{Name: ...}` instead of a top-level `Name` field; `GetName()` still reads `project.ProjectMetadata.Name` via the embedded meta.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcff83eef75750b5cef5f892f419b738d30a2483. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->