### PR TITLE
feat/PL 6131/operator compat

### DIFF
--- a/api/v1alpha1/project.go
+++ b/api/v1alpha1/project.go
@@ -11,7 +11,7 @@ import (
 const ProjectKind = "Project"
 
 type ProjectMetadata struct {
-	metav1.ObjectMeta `yaml:",inline" json:"metadata"`
+	metav1.ObjectMeta `yaml:",inline"`
 
 	// RelativePath is the catalog-relative path to this resource's yaml file (set only for list JSON/YAML output).
 	RelativePath string `yaml:"relativePath,omitempty" json:"relativePath,omitempty"`

--- a/api/v1alpha1/release.go
+++ b/api/v1alpha1/release.go
@@ -56,7 +56,7 @@ type ReleaseSpec struct {
 	Version string `yaml:"version,omitempty" json:"version,omitempty"`
 
 	// Chart is the chart that the release is based on.
-	Chart ReleaseChart `yaml:"chart,omitempty" json:"chart"`
+	Chart ReleaseChart `yaml:"chart,omitempty" json:"chart,omitzero"`
 
 	// Namespace is the namespace that the release is deployed to.
 	Namespace string `yaml:"namespace,omitempty" json:"namespace,omitempty"`


### PR DESCRIPTION
- **feat(PL-6131): make Project CR operator compatible with apimachinery meta**
- **fix(PL-6131): fix release.chart by making it optional for operator compat**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two struct-tag changes affect serialization only; no runtime logic or validation paths are modified in this diff.
> 
> **Overview**
> Aligns **Project** and **Release** API types with Kubernetes operator / apimachinery expectations via struct tag tweaks only.
> 
> **Project:** The embedded `metav1.ObjectMeta` on `ProjectMetadata` no longer carries a separate `json:"metadata"` on the inline field—only `yaml:",inline"`—so JSON encoding matches how nested metadata is expected for CRD-style resources.
> 
> **Release:** `ReleaseSpec.Chart` JSON encoding adds **`omitzero`**, so an unset/zero `ReleaseChart` is omitted from JSON instead of always serializing `chart`, treating chart as optional for operator consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18e84dbd81137f0a2c02ebb2e2318b6ec9b5854c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->