### PR TITLE
feat(PL-6433): introduce org-local+lock tag

### DIFF
--- a/internal/yml/merge.go
+++ b/internal/yml/merge.go
@@ -159,15 +159,15 @@ func markLockedValuesAsTodo(node *yaml.Node, locked bool) *yaml.Node {
 }
 
 func IsLocked(node *yaml.Node) bool {
-	return node != nil && node.Tag == "!lock"
+	return node != nil && (node.Tag == TagLock || node.Tag == TagOrgLocalPlusLock)
 }
 
 func IsLocal(node *yaml.Node) bool {
-	return node != nil && node.Tag == "!local"
+	return node != nil && node.Tag == TagLocal
 }
 
 func IsOrgLocal(node *yaml.Node) bool {
-	return node != nil && node.Tag == "!org-local"
+	return node != nil && (node.Tag == TagOrgLocal || node.Tag == TagOrgLocalPlusLock)
 }
 
 type KeyValuePair struct {

--- a/internal/yml/merge_test.go
+++ b/internal/yml/merge_test.go
@@ -786,3 +786,20 @@ func TestOrgLocalMerge(t *testing.T) {
 	result = Merge(&dst, &src, false)
 	require.Equal(t, "not-found", FindNodeValueOrDefault(result, "jeans", "not-found"))
 }
+
+func TestOrgLocalPlusLockMerge(t *testing.T) {
+	var src, dst yaml.Node
+
+	require.NoError(t, yaml.Unmarshal([]byte(`{
+	  apple: bottom,
+	  jeans: !org-local+lock boots,
+	}`), &src))
+
+	require.NoError(t, yaml.Unmarshal([]byte(`{}`), &dst))
+
+	result := Merge(&dst, &src, true)
+	require.Equal(t, "TODO", FindNodeValueOrDefault(result, "jeans", "not-found"))
+
+	result = Merge(&dst, &src, false)
+	require.Equal(t, "not-found", FindNodeValueOrDefault(result, "jeans", "not-found"))
+}

--- a/internal/yml/tags.go
+++ b/internal/yml/tags.go
@@ -12,6 +12,18 @@ var StandardTags = []string{
 	"!!merge",
 }
 
-var CustomTags = []string{"!lock", "!local", "!org-local"}
+const (
+	TagLock             = "!lock"
+	TagLocal            = "!local"
+	TagOrgLocal         = "!org-local"
+	TagOrgLocalPlusLock = "!org-local+lock"
+)
+
+var CustomTags = []string{
+	TagLock,
+	TagLocal,
+	TagOrgLocal,
+	TagOrgLocalPlusLock,
+}
 
 var KnownTags = append(StandardTags, CustomTags...)


### PR DESCRIPTION
When we introduced the `!org-local` we didn't fully account that marking a tag as org-local would disallow a user to mark that field as locked for the local org.

This PR adds a new tag to combine the concept of locked and org-local.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized YAML tag and predicate changes with a focused test; no auth or external API surface.
> 
> **Overview**
> Adds a new custom YAML tag **`!org-local+lock`** so a field can be both org-scoped and locked for downstream orgs, which **`!org-local` alone could not express**.
> 
> Tag constants in `tags.go` replace inline strings, and **`CustomTags`** now includes the new tag. **`IsLocked`** and **`IsOrgLocal`** treat **`!org-local+lock`** as locked and org-local respectively, so existing merge/purge/TODO behavior applies without separate code paths.
> 
> A merge test confirms same-org merges surface **`TODO`** for locked values and cross-org merges drop the key like plain **`!org-local`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae1d031ccc8d8e7120bc1564549107e2396a038f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->