### PR TITLE
feat(PL-6287): extract config to catalog

### DIFF
--- a/api/v1alpha1/catalog.go
+++ b/api/v1alpha1/catalog.go
@@ -1,0 +1,23 @@
+package v1alpha1
+
+import (
+	"github.com/nestoca/joy/internal/helm"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type Catalog struct {
+	metav1.TypeMeta   `yaml:",inline"`
+	metav1.ObjectMeta `json:"metadata" yaml:"metadata"`
+	Spec              CatalogSpec `json:"spec" yaml:"spec"`
+}
+
+type CatalogSpec struct {
+	RepoURL  string        `json:"repoUrl" yaml:"repoUrl"`
+	Revision string        `json:"revision" yaml:"revision"`
+	Charts   CatalogCharts `json:"charts,omitzero" yaml:"charts"`
+}
+
+type CatalogCharts struct {
+	Default string                `json:"default" yaml:"default"`
+	Refs    map[string]helm.Chart `json:"refs" yaml:"refs"`
+}

--- a/api/v1alpha1/environment.go
+++ b/api/v1alpha1/environment.go
@@ -12,8 +12,6 @@ import (
 	"github.com/nestoca/joy/internal/yml"
 )
 
-const EnvironmentKind = "Environment"
-
 type EnvironmentMetadata struct {
 	metav1.ObjectMeta `yaml:",inline"`
 

--- a/api/v1alpha1/project.go
+++ b/api/v1alpha1/project.go
@@ -8,8 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const ProjectKind = "Project"
-
 type ProjectMetadata struct {
 	metav1.ObjectMeta `yaml:",inline"`
 

--- a/api/v1alpha1/release.go
+++ b/api/v1alpha1/release.go
@@ -12,8 +12,6 @@ import (
 	"github.com/nestoca/joy/internal/yml"
 )
 
-const ReleaseKind = "Release"
-
 type ReleaseMetadata struct {
 	metav1.ObjectMeta `yaml:",inline"`
 

--- a/api/v1alpha1/scheme.go
+++ b/api/v1alpha1/scheme.go
@@ -10,14 +10,21 @@ const (
 	ReleaseKind     = "Release"
 	EnvironmentKind = "Environment"
 	ProjectKind     = "Project"
+	CatalogKind     = "Catalog"
 )
 
 var GroupVersion = schema.GroupVersion{Group: Group, Version: Version}
 
-var EnvironmentGK = schema.GroupKind{Group: Group, Kind: EnvironmentKind}
-var ProjectGK = schema.GroupKind{Group: Group, Kind: ProjectKind}
-var ReleaseGK = schema.GroupKind{Group: Group, Kind: ReleaseKind}
+var (
+	EnvironmentGK = schema.GroupKind{Group: Group, Kind: EnvironmentKind}
+	ProjectGK     = schema.GroupKind{Group: Group, Kind: ProjectKind}
+	ReleaseGK     = schema.GroupKind{Group: Group, Kind: ReleaseKind}
+	CatalogGK     = schema.GroupKind{Group: Group, Kind: CatalogKind}
+)
 
-var EnvironmentGVK = schema.GroupVersionKind{Group: Group, Version: Version, Kind: EnvironmentKind}
-var ProjectGVK = schema.GroupVersionKind{Group: Group, Version: Version, Kind: ProjectKind}
-var ReleaseGVK = schema.GroupVersionKind{Group: Group, Version: Version, Kind: ReleaseKind}
+var (
+	EnvironmentGVK = schema.GroupVersionKind{Group: Group, Version: Version, Kind: EnvironmentKind}
+	ProjectGVK     = schema.GroupVersionKind{Group: Group, Version: Version, Kind: ProjectKind}
+	ReleaseGVK     = schema.GroupVersionKind{Group: Group, Version: Version, Kind: ReleaseKind}
+	CatalogGVK     = schema.GroupVersionKind{Group: Group, Version: Version, Kind: CatalogKind}
+)

--- a/api/v1alpha1/scheme.go
+++ b/api/v1alpha1/scheme.go
@@ -1,11 +1,23 @@
 package v1alpha1
 
-import "k8s.io/apimachinery/pkg/runtime/schema"
-
-var SchemeGroupVersion = schema.GroupVersion{Group: "joy.nesto.ca", Version: "v1alpha1"}
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
 
 const (
-	KindRelease     = "Release"
-	KindEnvironment = "Environment"
-	KindProject     = "Project"
+	Group           = "joy.nesto.ca"
+	Version         = "v1alpha1"
+	ReleaseKind     = "Release"
+	EnvironmentKind = "Environment"
+	ProjectKind     = "Project"
 )
+
+var GroupVersion = schema.GroupVersion{Group: Group, Version: Version}
+
+var EnvironmentGK = schema.GroupKind{Group: Group, Kind: EnvironmentKind}
+var ProjectGK = schema.GroupKind{Group: Group, Kind: ProjectKind}
+var ReleaseGK = schema.GroupKind{Group: Group, Kind: ReleaseKind}
+
+var EnvironmentGVK = schema.GroupVersionKind{Group: Group, Version: Version, Kind: EnvironmentKind}
+var ProjectGVK = schema.GroupVersionKind{Group: Group, Version: Version, Kind: ProjectKind}
+var ReleaseGVK = schema.GroupVersionKind{Group: Group, Version: Version, Kind: ReleaseKind}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -215,14 +215,11 @@ func Load(ctx context.Context, configDir, catalogDir string) (*Config, error) {
 }
 
 func MergeCatalogResourceIntoCatalogConfig(catalogConfig *Catalog, catalogResource *v1alpha1.Catalog) error {
-	if catalogConfig.Charts == nil {
-		catalogConfig.Charts = make(map[string]helm.Chart)
+	if refs := catalogResource.Spec.Charts.Refs; refs != nil {
+		catalogConfig.Charts = refs
 	}
-	for key, chart := range catalogResource.Spec.Charts.Refs {
-		catalogConfig.Charts[key] = chart
-	}
-	if catalogResource.Spec.Charts.Default != "" {
-		catalogConfig.DefaultChartRef = catalogResource.Spec.Charts.Default
+	if defaultRef := catalogResource.Spec.Charts.Default; defaultRef != "" {
+		catalogConfig.DefaultChartRef = defaultRef
 	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,14 +12,16 @@ import (
 	"golang.org/x/mod/semver"
 	"gopkg.in/yaml.v3"
 
+	"github.com/nestoca/joy/api/v1alpha1"
 	"github.com/nestoca/joy/internal/observability"
 	"github.com/nestoca/joy/pkg/helm"
 )
 
 const (
-	CatalogConfigFile = "joy.yaml"
-	JoyrcFile         = ".joyrc"
-	JoyDefaultDir     = ".joy"
+	CatalogConfigFile   = "joy.yaml"
+	CatalogResourceFile = "catalog.yaml"
+	JoyrcFile           = ".joyrc"
+	JoyDefaultDir       = ".joy"
 )
 
 type User struct {
@@ -190,10 +192,19 @@ func Load(ctx context.Context, configDir, catalogDir string) (*Config, error) {
 
 	cfg.CatalogDir = cmp.Or(catalogDir, cfg.CatalogDir, filepath.Join(homeDir, JoyDefaultDir))
 
-	catalogConfigPath := filepath.Join(cfg.CatalogDir, CatalogConfigFile)
+	catalogResourcePath := filepath.Join(cfg.CatalogDir, CatalogResourceFile)
+	var catalogResource v1alpha1.Catalog
+	if err := LoadFile(catalogResourcePath, &catalogResource); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("loading catalog resource %s: %w", catalogResourcePath, err)
+	}
 
+	catalogConfigPath := filepath.Join(cfg.CatalogDir, CatalogConfigFile)
 	if err := LoadFile(catalogConfigPath, &cfg.Catalog); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return nil, fmt.Errorf("loading catalog config %s: %w", catalogConfigPath, err)
+	}
+
+	if err := MergeCatalogResourceIntoCatalogConfig(&cfg.Catalog, &catalogResource); err != nil {
+		return nil, fmt.Errorf("merging catalog resource into catalog config: %w", err)
 	}
 
 	if err := cfg.Validate(); err != nil {
@@ -201,6 +212,19 @@ func Load(ctx context.Context, configDir, catalogDir string) (*Config, error) {
 	}
 
 	return &cfg, nil
+}
+
+func MergeCatalogResourceIntoCatalogConfig(catalogConfig *Catalog, catalogResource *v1alpha1.Catalog) error {
+	if catalogConfig.Charts == nil {
+		catalogConfig.Charts = make(map[string]helm.Chart)
+	}
+	for key, chart := range catalogResource.Spec.Charts.Refs {
+		catalogConfig.Charts[key] = chart
+	}
+	if catalogResource.Spec.Charts.Default != "" {
+		catalogConfig.DefaultChartRef = catalogResource.Spec.Charts.Default
+	}
+	return nil
 }
 
 func (cfg Config) Validate() error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -22,7 +22,7 @@ func TestMergeCatalogResourceIntoCatalogConfig(t *testing.T) {
 		expected         Catalog
 	}{
 		{
-			name: "catalog resource adds charts and default",
+			name: "catalog resource replaces charts and default",
 			catalogConfig: Catalog{
 				Charts: map[string]helm.Chart{
 					"joy-only": {
@@ -49,11 +49,6 @@ func TestMergeCatalogResourceIntoCatalogConfig(t *testing.T) {
 			},
 			expected: Catalog{
 				Charts: map[string]helm.Chart{
-					"joy-only": {
-						RepoURL: "joy.example.com",
-						Name:    "charts/joy-only",
-						Version: "1.0.0",
-					},
 					"catalog-chart": {
 						RepoURL: "catalog.example.com",
 						Name:    "charts/catalog",
@@ -131,7 +126,37 @@ func TestMergeCatalogResourceIntoCatalogConfig(t *testing.T) {
 			},
 		},
 		{
-			name:          "nil charts map is initialized from catalog resource",
+			name: "catalog resource default only leaves joy charts unchanged",
+			catalogConfig: Catalog{
+				Charts: map[string]helm.Chart{
+					"joy-only": {
+						RepoURL: "joy.example.com",
+						Name:    "charts/joy-only",
+						Version: "1.0.0",
+					},
+				},
+				DefaultChartRef: "joy-only",
+			},
+			catalogResource: v1alpha1.Catalog{
+				Spec: v1alpha1.CatalogSpec{
+					Charts: v1alpha1.CatalogCharts{
+						Default: "joy-only",
+					},
+				},
+			},
+			expected: Catalog{
+				Charts: map[string]helm.Chart{
+					"joy-only": {
+						RepoURL: "joy.example.com",
+						Name:    "charts/joy-only",
+						Version: "1.0.0",
+					},
+				},
+				DefaultChartRef: "joy-only",
+			},
+		},
+		{
+			name:          "nil joy charts map is replaced from catalog resource",
 			catalogConfig: Catalog{},
 			catalogResource: v1alpha1.Catalog{
 				Spec: v1alpha1.CatalogSpec{
@@ -269,11 +294,6 @@ spec:
 			expected: Catalog{
 				MinVersion: "v1.0.0",
 				Charts: map[string]helm.Chart{
-					"joy-only": {
-						RepoURL: "joy.example.com",
-						Name:    "charts/joy-only",
-						Version: "1.0.0",
-					},
 					"example-chart": {
 						RepoURL: "example.com",
 						Name:    "charts/generic",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -200,21 +200,23 @@ func TestLoadCatalogConfig(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name     string
-		joyYAML  string
+		name        string
+		joyYAML     string
 		catalogYAML string
-		expected Catalog
+		expected    Catalog
 	}{
 		{
 			name: "joy.yaml only",
-			joyYAML: `
-charts:
-  joy-chart:
-    repoUrl: joy.example.com
-    name: charts/joy
-    version: 1.0.0
-defaultChartRef: joy-chart
-`,
+			joyYAML: `{
+				charts: {
+					joy-chart: {
+						repoUrl: "joy.example.com",
+						name: "charts/joy",
+						version: "1.0.0"
+					}
+				},
+				defaultChartRef: "joy-chart"
+			}`,
 			expected: Catalog{
 				Charts: map[string]helm.Chart{
 					"joy-chart": {
@@ -228,22 +230,28 @@ defaultChartRef: joy-chart
 		},
 		{
 			name: "catalog.yaml only",
-			catalogYAML: `
-apiVersion: joy.nesto.ca/v1alpha1
-kind: Catalog
-metadata:
-  name: catalog
-spec:
-  charts:
-    default: example-chart
-    refs:
-      example-chart:
-        repoUrl: example.com
-        name: charts/generic
-        version: 1.2.3
-        mappings:
-          key1: value1
-`,
+			catalogYAML: `{
+				apiVersion: joy.nesto.ca/v1alpha1,
+				kind: Catalog,
+				metadata: {
+					name: catalog
+				},
+				spec: {
+					charts: {
+						default: example-chart,
+						refs: {
+							example-chart: {
+								repoUrl: example.com,
+								name: charts/generic,
+								version: 1.2.3,
+								mappings: {
+									key1: value1
+								}
+							}
+						}
+					}
+				}
+			}`,
 			expected: Catalog{
 				Charts: map[string]helm.Chart{
 					"example-chart": {
@@ -260,37 +268,46 @@ spec:
 		},
 		{
 			name: "catalog.yaml takes priority over joy.yaml",
-			joyYAML: `
-charts:
-  shared:
-    repoUrl: joy.example.com
-    name: charts/from-joy
-    version: 1.0.0
-  joy-only:
-    repoUrl: joy.example.com
-    name: charts/joy-only
-    version: 1.0.0
-defaultChartRef: joy-only
-minVersion: v1.0.0
-`,
-			catalogYAML: `
-apiVersion: joy.nesto.ca/v1alpha1
-kind: Catalog
-metadata:
-  name: catalog
-spec:
-  charts:
-    default: example-chart
-    refs:
-      example-chart:
-        repoUrl: example.com
-        name: charts/generic
-        version: 1.2.3
-      shared:
-        repoUrl: catalog.example.com
-        name: charts/from-catalog
-        version: 2.0.0
-`,
+			joyYAML: `{
+				charts: {
+					shared: {
+						repoUrl: "joy.example.com",
+						name: "charts/from-joy",
+						version: "1.0.0"
+					},
+					joy-only: {
+						repoUrl: "joy.example.com",
+						name: "charts/joy-only",
+						version: "1.0.0"
+					}
+				},
+				defaultChartRef: "joy-only",
+				minVersion: "v1.0.0"
+			}`,
+			catalogYAML: `{
+				apiVersion: joy.nesto.ca/v1alpha1,
+				kind: Catalog,
+				metadata: {
+					name: catalog
+				},
+				spec: {
+					charts: {
+						default: example-chart,
+						refs: {
+							example-chart: {
+								repoUrl: example.com,
+								name: charts/generic,
+								version: 1.2.3
+							},
+							shared: {
+								repoUrl: catalog.example.com,
+								name: charts/from-catalog,
+								version: 2.0.0
+							}
+						}
+					}
+				}
+			}`,
 			expected: Catalog{
 				MinVersion: "v1.0.0",
 				Charts: map[string]helm.Chart{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,336 @@
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/nestoca/joy/api/v1alpha1"
+	"github.com/nestoca/joy/pkg/helm"
+)
+
+func TestMergeCatalogResourceIntoCatalogConfig(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name             string
+		catalogConfig    Catalog
+		catalogResource  v1alpha1.Catalog
+		expected         Catalog
+	}{
+		{
+			name: "catalog resource adds charts and default",
+			catalogConfig: Catalog{
+				Charts: map[string]helm.Chart{
+					"joy-only": {
+						RepoURL: "joy.example.com",
+						Name:    "charts/joy-only",
+						Version: "1.0.0",
+					},
+				},
+				DefaultChartRef: "joy-only",
+			},
+			catalogResource: v1alpha1.Catalog{
+				Spec: v1alpha1.CatalogSpec{
+					Charts: v1alpha1.CatalogCharts{
+						Default: "catalog-chart",
+						Refs: map[string]helm.Chart{
+							"catalog-chart": {
+								RepoURL: "catalog.example.com",
+								Name:    "charts/catalog",
+								Version: "2.0.0",
+							},
+						},
+					},
+				},
+			},
+			expected: Catalog{
+				Charts: map[string]helm.Chart{
+					"joy-only": {
+						RepoURL: "joy.example.com",
+						Name:    "charts/joy-only",
+						Version: "1.0.0",
+					},
+					"catalog-chart": {
+						RepoURL: "catalog.example.com",
+						Name:    "charts/catalog",
+						Version: "2.0.0",
+					},
+				},
+				DefaultChartRef: "catalog-chart",
+			},
+		},
+		{
+			name: "catalog resource overrides joy config for same chart ref",
+			catalogConfig: Catalog{
+				Charts: map[string]helm.Chart{
+					"shared": {
+						RepoURL: "joy.example.com",
+						Name:    "charts/from-joy",
+						Version: "1.0.0",
+					},
+				},
+				DefaultChartRef: "shared",
+			},
+			catalogResource: v1alpha1.Catalog{
+				Spec: v1alpha1.CatalogSpec{
+					Charts: v1alpha1.CatalogCharts{
+						Default: "shared",
+						Refs: map[string]helm.Chart{
+							"shared": {
+								RepoURL: "catalog.example.com",
+								Name:    "charts/from-catalog",
+								Version: "2.0.0",
+								Mappings: map[string]any{
+									"key1": "value1",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: Catalog{
+				Charts: map[string]helm.Chart{
+					"shared": {
+						RepoURL: "catalog.example.com",
+						Name:    "charts/from-catalog",
+						Version: "2.0.0",
+						Mappings: map[string]any{
+							"key1": "value1",
+						},
+					},
+				},
+				DefaultChartRef: "shared",
+			},
+		},
+		{
+			name:            "empty catalog resource leaves joy config unchanged",
+			catalogConfig: Catalog{
+				Charts: map[string]helm.Chart{
+					"joy-only": {
+						RepoURL: "joy.example.com",
+						Name:    "charts/joy-only",
+						Version: "1.0.0",
+					},
+				},
+				DefaultChartRef: "joy-only",
+			},
+			catalogResource: v1alpha1.Catalog{},
+			expected: Catalog{
+				Charts: map[string]helm.Chart{
+					"joy-only": {
+						RepoURL: "joy.example.com",
+						Name:    "charts/joy-only",
+						Version: "1.0.0",
+					},
+				},
+				DefaultChartRef: "joy-only",
+			},
+		},
+		{
+			name:          "nil charts map is initialized from catalog resource",
+			catalogConfig: Catalog{},
+			catalogResource: v1alpha1.Catalog{
+				Spec: v1alpha1.CatalogSpec{
+					Charts: v1alpha1.CatalogCharts{
+						Default: "catalog-chart",
+						Refs: map[string]helm.Chart{
+							"catalog-chart": {
+								RepoURL: "catalog.example.com",
+								Name:    "charts/catalog",
+								Version: "2.0.0",
+							},
+						},
+					},
+				},
+			},
+			expected: Catalog{
+				Charts: map[string]helm.Chart{
+					"catalog-chart": {
+						RepoURL: "catalog.example.com",
+						Name:    "charts/catalog",
+						Version: "2.0.0",
+					},
+				},
+				DefaultChartRef: "catalog-chart",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			catalogConfig := tc.catalogConfig
+			require.NoError(t, MergeCatalogResourceIntoCatalogConfig(&catalogConfig, &tc.catalogResource))
+			require.Equal(t, tc.expected, catalogConfig)
+		})
+	}
+}
+
+func TestLoadCatalogConfig(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		joyYAML  string
+		catalogYAML string
+		expected Catalog
+	}{
+		{
+			name: "joy.yaml only",
+			joyYAML: `
+charts:
+  joy-chart:
+    repoUrl: joy.example.com
+    name: charts/joy
+    version: 1.0.0
+defaultChartRef: joy-chart
+`,
+			expected: Catalog{
+				Charts: map[string]helm.Chart{
+					"joy-chart": {
+						RepoURL: "joy.example.com",
+						Name:    "charts/joy",
+						Version: "1.0.0",
+					},
+				},
+				DefaultChartRef: "joy-chart",
+			},
+		},
+		{
+			name: "catalog.yaml only",
+			catalogYAML: `
+apiVersion: joy.nesto.ca/v1alpha1
+kind: Catalog
+metadata:
+  name: catalog
+spec:
+  charts:
+    default: example-chart
+    refs:
+      example-chart:
+        repoUrl: example.com
+        name: charts/generic
+        version: 1.2.3
+        mappings:
+          key1: value1
+`,
+			expected: Catalog{
+				Charts: map[string]helm.Chart{
+					"example-chart": {
+						RepoURL: "example.com",
+						Name:    "charts/generic",
+						Version: "1.2.3",
+						Mappings: map[string]any{
+							"key1": "value1",
+						},
+					},
+				},
+				DefaultChartRef: "example-chart",
+			},
+		},
+		{
+			name: "catalog.yaml takes priority over joy.yaml",
+			joyYAML: `
+charts:
+  shared:
+    repoUrl: joy.example.com
+    name: charts/from-joy
+    version: 1.0.0
+  joy-only:
+    repoUrl: joy.example.com
+    name: charts/joy-only
+    version: 1.0.0
+defaultChartRef: joy-only
+minVersion: v1.0.0
+`,
+			catalogYAML: `
+apiVersion: joy.nesto.ca/v1alpha1
+kind: Catalog
+metadata:
+  name: catalog
+spec:
+  charts:
+    default: example-chart
+    refs:
+      example-chart:
+        repoUrl: example.com
+        name: charts/generic
+        version: 1.2.3
+      shared:
+        repoUrl: catalog.example.com
+        name: charts/from-catalog
+        version: 2.0.0
+`,
+			expected: Catalog{
+				MinVersion: "v1.0.0",
+				Charts: map[string]helm.Chart{
+					"joy-only": {
+						RepoURL: "joy.example.com",
+						Name:    "charts/joy-only",
+						Version: "1.0.0",
+					},
+					"example-chart": {
+						RepoURL: "example.com",
+						Name:    "charts/generic",
+						Version: "1.2.3",
+					},
+					"shared": {
+						RepoURL: "catalog.example.com",
+						Name:    "charts/from-catalog",
+						Version: "2.0.0",
+					},
+				},
+				DefaultChartRef: "example-chart",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			catalogDir := t.TempDir()
+			if tc.joyYAML != "" {
+				require.NoError(t, os.WriteFile(filepath.Join(catalogDir, CatalogConfigFile), []byte(tc.joyYAML), 0o644))
+			}
+			if tc.catalogYAML != "" {
+				require.NoError(t, os.WriteFile(filepath.Join(catalogDir, CatalogResourceFile), []byte(tc.catalogYAML), 0o644))
+			}
+
+			cfg, err := Load(context.Background(), catalogDir, catalogDir)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, cfg.Catalog)
+		})
+	}
+}
+
+func TestLoadCatalogConfigErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid catalog.yaml", func(t *testing.T) {
+		t.Parallel()
+
+		catalogDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(catalogDir, CatalogResourceFile), []byte(":\n\tbad"), 0o644))
+
+		_, err := Load(context.Background(), catalogDir, catalogDir)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "loading catalog resource")
+	})
+
+	t.Run("invalid joy.yaml", func(t *testing.T) {
+		t.Parallel()
+
+		catalogDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(catalogDir, CatalogConfigFile), []byte(":\n\tbad"), 0o644))
+
+		_, err := Load(context.Background(), catalogDir, catalogDir)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "loading catalog config")
+	})
+}

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -1,0 +1,36 @@
+package helm
+
+import (
+	"net/url"
+
+	"github.com/davidmdm/x/xfs"
+)
+
+type Chart struct {
+	RepoURL  string         `json:"repoUrl" yaml:"repoUrl"`
+	Name     string         `json:"name" yaml:"name"`
+	Version  string         `json:"version" yaml:"version"`
+	Mappings map[string]any `json:"mappings,omitempty" yaml:"mappings"`
+}
+
+func (chart Chart) ToURL() (*url.URL, error) {
+	uri, err := url.Parse(chart.RepoURL)
+	if err != nil {
+		return nil, err
+	}
+
+	if uri.Scheme == "" {
+		uri.Scheme = "oci"
+		uri, err = url.Parse(uri.String())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return uri.JoinPath(chart.Name), nil
+}
+
+type ChartFS struct {
+	Chart
+	xfs.FS
+}

--- a/pkg/helm/cache.go
+++ b/pkg/helm/cache.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -15,6 +14,12 @@ import (
 	"github.com/davidmdm/x/xfs"
 
 	"github.com/nestoca/joy/api/v1alpha1"
+	"github.com/nestoca/joy/internal/helm"
+)
+
+type (
+	Chart   = helm.Chart
+	ChartFS = helm.ChartFS
 )
 
 type ChartCache struct {
@@ -22,35 +27,6 @@ type ChartCache struct {
 	DefaultChartRef string
 	Root            string
 	Puller
-}
-
-type Chart struct {
-	RepoURL  string         `yaml:"repoUrl"`
-	Name     string         `yaml:"name"`
-	Version  string         `yaml:"version"`
-	Mappings map[string]any `yaml:"mappings"`
-}
-
-func (chart Chart) ToURL() (*url.URL, error) {
-	uri, err := url.Parse(chart.RepoURL)
-	if err != nil {
-		return nil, err
-	}
-
-	if uri.Scheme == "" {
-		uri.Scheme = "oci"
-		uri, err = url.Parse(uri.String())
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return uri.JoinPath(chart.Name), nil
-}
-
-type ChartFS struct {
-	Chart
-	xfs.FS
 }
 
 func (cache ChartCache) GetReleaseChart(release *v1alpha1.Release) (Chart, error) {


### PR DESCRIPTION
This PR allows `joy` cli (and eventually `joy-generator`) to read catalog chart refs from either `joy.yaml` or `catalog.yaml`. The goal is to eventually only read chart refs from `catalog.yaml` and remove those from `joy.yaml`.

NOTE: That other [catalog PR](https://github.com/nestoca/catalog/pull/53575) must be merged first.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Chart resolution affects every release render/deploy; wrong merge or missing `catalog.yaml` could change which charts resolve until catalog PR lands, though legacy `joy.yaml` remains the fallback.
> 
> **Overview**
> Introduces a **`Catalog` v1alpha1 API** (`catalog.yaml`) so chart **refs**, **default chart**, and optional **repo/revision** live in a catalog resource instead of only in `joy.yaml`.
> 
> **Config loading** now reads `catalog.yaml`, merges `spec.charts` into the in-memory catalog config via `MergeCatalogResourceIntoCatalogConfig` (resource **refs** replace the whole charts map when present; **default** overrides when set), then keeps validating merged charts. Stderr hints whether legacy `joy.yaml` or catalog resource values were used.
> 
> **Scheme** centralizes group/version/kind constants and adds **Catalog** GVK/GK; per-file kind constants were removed in favor of `scheme.go`.
> 
> **Helm `Chart` / `ChartFS`** move to `internal/helm`; `pkg/helm` type-aliases them so cache behavior stays the same.
> 
> Tests cover merge edge cases and `Load` with joy-only, catalog-only, combined priority, and invalid YAML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce9526c45c13c59ae88327778f2222201063cc9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for a `catalog.yaml` resource to define chart references and a default chart.
  - Catalog chart mappings can now be merged across configuration sources, with resource-defined values taking priority when overlapping.
  - Chart repository URLs now more reliably resolve to OCI-style URLs, including when the scheme is omitted.

- **Bug Fixes**
  - Improved loading and validation behavior for both the catalog and base catalog configuration, with clearer error handling for invalid inputs.

- **Tests**
  - Added coverage for merging, priority behavior, empty/partial configs, and invalid configuration cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->