### PR TITLE
feat/PL 6289/crd tag fixes

### DIFF
--- a/api/v1alpha1/catalog.go
+++ b/api/v1alpha1/catalog.go
@@ -14,7 +14,7 @@ type Catalog struct {
 type CatalogSpec struct {
 	RepoURL  string        `json:"repoUrl" yaml:"repoUrl"`
 	Revision string        `json:"revision" yaml:"revision"`
-	Charts   CatalogCharts `json:"charts,omitzero" yaml:"charts"`
+	Charts   CatalogCharts `json:"charts,omitzero" yaml:"charts,omitempty"`
 }
 
 type CatalogCharts struct {

--- a/api/v1alpha1/environment.go
+++ b/api/v1alpha1/environment.go
@@ -37,7 +37,7 @@ type EnvironmentSpec struct {
 	Order int `yaml:"order,omitempty" json:"order,omitempty"`
 
 	// Promotion controls the promotion of releases to this environment.
-	Promotion Promotion `yaml:"promotion,omitempty" json:"promotion"`
+	Promotion Promotion `yaml:"promotion,omitempty" json:"promotion,omitzero"`
 
 	// Cluster is the name of environment's cluster.
 	Cluster string `yaml:"cluster,omitempty" json:"cluster,omitempty"`
@@ -70,10 +70,10 @@ type Environment struct {
 	Kind string `yaml:"kind,omitempty" json:"kind,omitempty"`
 
 	// EnvironmentMetadata is the metadata of the environment.
-	EnvironmentMetadata `yaml:"metadata,omitempty" json:"metadata"`
+	EnvironmentMetadata `yaml:"metadata,omitempty" json:"metadata,omitzero"`
 
 	// Spec is the spec of the environment.
-	Spec EnvironmentSpec `yaml:"spec,omitempty" json:"spec"`
+	Spec EnvironmentSpec `yaml:"spec,omitempty" json:"spec,omitzero"`
 
 	// File represents the in-memory yaml file of the project.
 	File *yml.File `yaml:"-" json:"-"`

--- a/api/v1alpha1/project.go
+++ b/api/v1alpha1/project.go
@@ -54,10 +54,10 @@ type Project struct {
 	Kind string `yaml:"kind,omitempty" json:"kind,omitempty"`
 
 	// ProjectMetadata is the metadata of the project.
-	ProjectMetadata `yaml:"metadata,omitempty" json:"metadata"`
+	ProjectMetadata `yaml:"metadata,omitempty" json:"metadata,omitzero"`
 
 	// Spec is the spec of the project.
-	Spec ProjectSpec `yaml:"spec,omitempty" json:"spec"`
+	Spec ProjectSpec `yaml:"spec,omitempty" json:"spec,omitzero"`
 
 	// File represents the in-memory yaml file of the project.
 	File *yml.File `yaml:"-" json:"-"`

--- a/api/v1alpha1/release.go
+++ b/api/v1alpha1/release.go
@@ -74,10 +74,10 @@ type Release struct {
 	Kind string `yaml:"kind,omitempty" json:"kind,omitempty"`
 
 	// ReleaseMetadata is the metadata of the release.
-	ReleaseMetadata `yaml:"metadata,omitempty" json:"metadata"`
+	ReleaseMetadata `yaml:"metadata,omitempty" json:"metadata,omitzero"`
 
 	// Spec is the spec of the release.
-	Spec ReleaseSpec `yaml:"spec,omitempty" json:"spec"`
+	Spec ReleaseSpec `yaml:"spec,omitempty" json:"spec,omitzero"`
 
 	// File represents the in-memory yaml file of the release.
 	File *yml.File `yaml:"-" json:"-"`


### PR DESCRIPTION
- **feat(PL-6289): fix yaml and json tag mismatches for better crd openapi generation**


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tag-only changes on API structs; may shift JSON output for zero-value nested fields and update generated OpenAPI, with no business-logic edits.
> 
> **Overview**
> Aligns **yaml** and **json** struct tags on `api/v1alpha1` catalog, environment, project, and release types so CRD/OpenAPI generation sees consistent optional-field behavior.
> 
> **Catalog:** `CatalogSpec.Charts` gains `yaml:"charts,omitempty"` to pair with existing `json:"charts,omitzero"`.
> 
> **Environment, Project, Release:** embedded `metadata` and `spec` fields now use `json:"...,omitzero"` alongside existing `yaml:"...,omitempty"`. **Environment** `spec.promotion` gets the same `json:"promotion,omitzero"` treatment as its yaml tag.
> 
> No runtime logic or validation paths change—only serialization/schema metadata on the API structs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01217d6fb2caad1ab570ee53d27bf8bc3016fdc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON and YAML serialization for catalog, environment, project, and release resources.
  * Empty or zero-valued fields are now omitted from serialized output, producing cleaner and more accurate resource representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->