### PR TITLE
feat(PL-6895): support custom tags on mapping keys

### DIFF
--- a/api/v1alpha1/release.go
+++ b/api/v1alpha1/release.go
@@ -98,6 +98,17 @@ func (release *Release) UnmarshalYAML(node *yaml.Node) error {
 	return stripCustomTags(yml.Clone(node)).Decode((*raw)(release))
 }
 
+func (release *Release) FromTree() (*Release, error) {
+	type alt Release
+	var result Release
+	if err := release.File.Tree.Decode((*alt)(&result)); err != nil {
+		return nil, fmt.Errorf("decoding: %w", err)
+	}
+	result.Environment = release.Environment
+	result.Project = release.Project
+	return &result, nil
+}
+
 func IsValidRelease(apiVersion, kind string) bool {
 	return apiVersion == "joy.nesto.ca/v1alpha1" && kind == ReleaseKind
 }

--- a/cmd/joy/release.go
+++ b/cmd/joy/release.go
@@ -635,6 +635,7 @@ func NewReleaseRenderCmd() *cobra.Command {
 func NewValidateCommand() *cobra.Command {
 	var env string
 	var noRender bool
+	var noMappingValueTags bool
 
 	cmd := &cobra.Command{
 		Use:   "validate [releases...]",
@@ -672,9 +673,10 @@ func NewValidateCommand() *cobra.Command {
 			}
 
 			return validate.Validate(cmd.Context(), validate.ValidateParams{
-				Releases: releases,
-				NoRender: noRender,
-				Helm:     helm.CLI{IO: internal.IO{Out: cmd.OutOrStdout(), Err: cmd.ErrOrStderr(), In: cmd.InOrStdin()}},
+				Releases:              releases,
+				NoRender:              noRender,
+				NoTagsOnMappingValues: noMappingValueTags,
+				Helm:                  helm.CLI{IO: internal.IO{Out: cmd.OutOrStdout(), Err: cmd.ErrOrStderr(), In: cmd.InOrStdin()}},
 				ChartCache: helm.ChartCache{
 					Refs:            cfg.Charts,
 					DefaultChartRef: cfg.DefaultChartRef,
@@ -687,6 +689,7 @@ func NewValidateCommand() *cobra.Command {
 
 	cmd.Flags().StringVarP(&env, "env", "e", "", "environment to select release from.")
 	cmd.Flags().BoolVarP(&noRender, "no-render", "", false, "skips release rendering validation step")
+	cmd.Flags().BoolVarP(&noMappingValueTags, "no-tags-on-mapping-values", "", false, "disallows tags on mapping values")
 	return cmd
 }
 

--- a/cmd/joy/release.go
+++ b/cmd/joy/release.go
@@ -635,7 +635,7 @@ func NewReleaseRenderCmd() *cobra.Command {
 func NewValidateCommand() *cobra.Command {
 	var env string
 	var noRender bool
-	var noMappingValueTags bool
+	var noValueTags bool
 
 	cmd := &cobra.Command{
 		Use:   "validate [releases...]",
@@ -673,10 +673,10 @@ func NewValidateCommand() *cobra.Command {
 			}
 
 			return validate.Validate(cmd.Context(), validate.ValidateParams{
-				Releases:              releases,
-				NoRender:              noRender,
-				NoTagsOnMappingValues: noMappingValueTags,
-				Helm:                  helm.CLI{IO: internal.IO{Out: cmd.OutOrStdout(), Err: cmd.ErrOrStderr(), In: cmd.InOrStdin()}},
+				Releases:    releases,
+				NoRender:    noRender,
+				NoValueTags: noValueTags,
+				Helm:        helm.CLI{IO: internal.IO{Out: cmd.OutOrStdout(), Err: cmd.ErrOrStderr(), In: cmd.InOrStdin()}},
 				ChartCache: helm.ChartCache{
 					Refs:            cfg.Charts,
 					DefaultChartRef: cfg.DefaultChartRef,
@@ -689,7 +689,7 @@ func NewValidateCommand() *cobra.Command {
 
 	cmd.Flags().StringVarP(&env, "env", "e", "", "environment to select release from.")
 	cmd.Flags().BoolVarP(&noRender, "no-render", "", false, "skips release rendering validation step")
-	cmd.Flags().BoolVarP(&noMappingValueTags, "no-tags-on-mapping-values", "", false, "disallows tags on mapping values")
+	cmd.Flags().BoolVarP(&noValueTags, "no-value-tags", "", false, "disallows tags on mapping values")
 	return cmd
 }
 

--- a/cmd/joy/release.go
+++ b/cmd/joy/release.go
@@ -636,6 +636,7 @@ func NewValidateCommand() *cobra.Command {
 	var env string
 	var noRender bool
 	var noValueTags bool
+	var useRawYaml bool
 
 	cmd := &cobra.Command{
 		Use:   "validate [releases...]",
@@ -676,6 +677,7 @@ func NewValidateCommand() *cobra.Command {
 				Releases:    releases,
 				NoRender:    noRender,
 				NoValueTags: noValueTags,
+				UseRawYaml:  useRawYaml,
 				Helm:        helm.CLI{IO: internal.IO{Out: cmd.OutOrStdout(), Err: cmd.ErrOrStderr(), In: cmd.InOrStdin()}},
 				ChartCache: helm.ChartCache{
 					Refs:            cfg.Charts,
@@ -690,6 +692,8 @@ func NewValidateCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&env, "env", "e", "", "environment to select release from.")
 	cmd.Flags().BoolVarP(&noRender, "no-render", "", false, "skips release rendering validation step")
 	cmd.Flags().BoolVarP(&noValueTags, "no-value-tags", "", false, "disallows tags on mapping values")
+	cmd.Flags().BoolVarP(&useRawYaml, "raw-yaml", "", false, "validate against raw yaml release instead of joy parsed release")
+
 	return cmd
 }
 

--- a/cmd/tag-migrator/main.go
+++ b/cmd/tag-migrator/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"slices"
+
+	"github.com/nestoca/joy/internal/yml"
+	joy "github.com/nestoca/joy/pkg"
+	"gopkg.in/yaml.v3"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	catalog, err := joy.LoadCatalog(context.Background(), "")
+	if err != nil {
+		return fmt.Errorf("failed to load catalog: %w", err)
+	}
+
+	for _, cross := range catalog.Releases.Items {
+		for _, release := range cross.Releases {
+			if release == nil {
+				continue
+			}
+
+			moveTags(release.File.Tree)
+
+			data, err := release.File.ToYaml()
+			if err != nil {
+				return fmt.Errorf("failed to marshal data for release: %s/%s: %v", release.Environment.Name, release.Name, err)
+			}
+
+			if err := os.WriteFile(release.File.Path, []byte(data), 0o644); err != nil {
+				return fmt.Errorf("failed to write data for release: %s/%s: %v", release.Environment.Name, release.Name, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func moveTags(node *yaml.Node) {
+	if node.Kind == yaml.MappingNode {
+		for i := 0; i < len(node.Content); i += 2 {
+			var (
+				key   = node.Content[i]
+				value = node.Content[i+1]
+			)
+			if slices.Contains(yml.CustomTags, value.Tag) {
+				key.Tag = value.Tag
+				value.Tag = ""
+			}
+		}
+	}
+	for _, node := range node.Content {
+		moveTags(node)
+	}
+}

--- a/internal/build/promote.go
+++ b/internal/build/promote.go
@@ -43,17 +43,17 @@ func Promote(opts Opts) error {
 
 	promotionCount := 0
 	for _, release := range releases {
-		versionNode, err := yml.FindNode(release.File.Tree, "spec.version")
+		versionKeypair, err := yml.FindNodeKeyPair(release.File.Tree, "spec.version")
 		if err != nil {
 			return fmt.Errorf("release %s has no version property: %w", release.Name, err)
 		}
 
-		if yml.IsLocked(versionNode) {
+		if yml.IsLocked(versionKeypair.Key) || yml.IsLocked(versionKeypair.Value) {
 			fmt.Printf("⚠️ Skipping promotion of release %s: version is locked\n", style.Resource(release.Name))
 			continue
 		}
 
-		versionNode.Value = opts.Version
+		versionKeypair.Value.Value = opts.Version
 		if err := release.File.UpdateYamlFromTree(); err != nil {
 			return fmt.Errorf("updating release yaml from node tree: %w", err)
 		}

--- a/internal/release/render/render.go
+++ b/internal/release/render/render.go
@@ -31,7 +31,12 @@ type RenderParams struct {
 }
 
 func Render(ctx context.Context, params RenderParams) (string, error) {
-	values, err := HydrateValues(params.Release, params.Chart)
+	release, err := params.Release.FromTree()
+	if err != nil {
+		return "", fmt.Errorf("failed to parse release from file tree: %w", err)
+	}
+
+	values, err := HydrateValues(release, params.Chart)
 	if err != nil {
 		return "", fmt.Errorf("hydrating values: %w", err)
 	}

--- a/internal/release/render/render.go
+++ b/internal/release/render/render.go
@@ -28,12 +28,22 @@ type RenderParams struct {
 	Chart      *helm.ChartFS
 	Helm       helm.PullRenderer
 	ValuesOnly bool
+	UseRawYaml bool
 }
 
 func Render(ctx context.Context, params RenderParams) (string, error) {
-	release, err := params.Release.FromTree()
+	release, err := func() (*v1alpha1.Release, error) {
+		if !params.UseRawYaml {
+			return params.Release, nil
+		}
+		release, err := params.Release.FromTree()
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse release from file tree: %w", err)
+		}
+		return release, nil
+	}()
 	if err != nil {
-		return "", fmt.Errorf("failed to parse release from file tree: %w", err)
+		return "", err
 	}
 
 	values, err := HydrateValues(release, params.Chart)

--- a/internal/release/render/render_test.go
+++ b/internal/release/render/render_test.go
@@ -11,10 +11,12 @@ import (
 
 	"github.com/davidmdm/x/xfs"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/nestoca/joy/api/v1alpha1"
 	"github.com/nestoca/joy/internal"
+	"github.com/nestoca/joy/internal/yml"
 	"github.com/nestoca/joy/pkg/helm"
 )
 
@@ -217,6 +219,14 @@ func TestRenderRelease(t *testing.T) {
 					require.NoError(t, fmt.Errorf("%v", err))
 				}
 			}()
+
+			data, err := yaml.Marshal(tc.Params.Release)
+			require.NoError(t, err)
+
+			file, err := yml.NewFile("test.yaml", data)
+			require.NoError(t, err)
+
+			tc.Params.Release.File = file
 
 			result, err := Render(context.Background(), RenderParams{
 				Release: tc.Params.Release,

--- a/internal/release/validate/validate.go
+++ b/internal/release/validate/validate.go
@@ -15,10 +15,11 @@ import (
 )
 
 type ValidateParams struct {
-	Releases   []*v1alpha1.Release
-	Helm       helm.PullRenderer
-	ChartCache helm.ChartCache
-	NoRender   bool
+	Releases              []*v1alpha1.Release
+	Helm                  helm.PullRenderer
+	ChartCache            helm.ChartCache
+	NoRender              bool
+	NoTagsOnMappingValues bool
 }
 
 func Validate(ctx context.Context, params ValidateParams) error {
@@ -35,9 +36,10 @@ func Validate(ctx context.Context, params ValidateParams) error {
 		}
 
 		validateParams := ValidateReleaseParams{
-			Chart:   chart,
-			Release: release,
-			Helm:    params.Helm,
+			Chart:                 chart,
+			Release:               release,
+			Helm:                  params.Helm,
+			NoTagsOnMappingValues: params.NoTagsOnMappingValues,
 		}
 
 		if err := ValidateRelease(ctx, validateParams); err != nil {
@@ -49,9 +51,10 @@ func Validate(ctx context.Context, params ValidateParams) error {
 }
 
 type ValidateReleaseParams struct {
-	Release *v1alpha1.Release
-	Chart   *helm.ChartFS
-	Helm    helm.PullRenderer
+	Release               *v1alpha1.Release
+	Chart                 *helm.ChartFS
+	Helm                  helm.PullRenderer
+	NoTagsOnMappingValues bool
 }
 
 func ValidateRelease(ctx context.Context, params ValidateReleaseParams) error {
@@ -64,6 +67,16 @@ func ValidateRelease(ctx context.Context, params ValidateReleaseParams) error {
 
 	if yml.HasLockedTodos(params.Release.File.Tree) {
 		return errors.New("contains locked TODO")
+	}
+
+	if params.NoTagsOnMappingValues {
+		if nodes := yml.GetMappingValueNodesWithTags(params.Release.File.Tree); len(nodes) > 0 {
+			errs := make([]error, len(nodes))
+			for i, node := range nodes {
+				errs[i] = fmt.Errorf("line: %d", node.Line)
+			}
+			return xerr.MultiErrFrom("found invalid tags on mapping values", errs...)
+		}
 	}
 
 	if params.Chart == nil {

--- a/internal/release/validate/validate.go
+++ b/internal/release/validate/validate.go
@@ -20,6 +20,7 @@ type ValidateParams struct {
 	ChartCache  helm.ChartCache
 	NoRender    bool
 	NoValueTags bool
+	UseRawYaml  bool
 }
 
 func Validate(ctx context.Context, params ValidateParams) error {
@@ -40,6 +41,7 @@ func Validate(ctx context.Context, params ValidateParams) error {
 			Release:               release,
 			Helm:                  params.Helm,
 			NoTagsOnMappingValues: params.NoValueTags,
+			UseRawYaml:            params.UseRawYaml,
 		}
 
 		if err := ValidateRelease(ctx, validateParams); err != nil {
@@ -55,6 +57,7 @@ type ValidateReleaseParams struct {
 	Chart                 *helm.ChartFS
 	Helm                  helm.PullRenderer
 	NoTagsOnMappingValues bool
+	UseRawYaml            bool
 }
 
 func ValidateRelease(ctx context.Context, params ValidateReleaseParams) error {
@@ -84,9 +87,10 @@ func ValidateRelease(ctx context.Context, params ValidateReleaseParams) error {
 	}
 
 	renderOpts := render.RenderParams{
-		Release: params.Release,
-		Chart:   params.Chart,
-		Helm:    params.Helm,
+		Release:    params.Release,
+		Chart:      params.Chart,
+		Helm:       params.Helm,
+		UseRawYaml: params.UseRawYaml,
 	}
 
 	_, err := render.Render(ctx, renderOpts)

--- a/internal/release/validate/validate.go
+++ b/internal/release/validate/validate.go
@@ -15,11 +15,11 @@ import (
 )
 
 type ValidateParams struct {
-	Releases              []*v1alpha1.Release
-	Helm                  helm.PullRenderer
-	ChartCache            helm.ChartCache
-	NoRender              bool
-	NoTagsOnMappingValues bool
+	Releases    []*v1alpha1.Release
+	Helm        helm.PullRenderer
+	ChartCache  helm.ChartCache
+	NoRender    bool
+	NoValueTags bool
 }
 
 func Validate(ctx context.Context, params ValidateParams) error {
@@ -39,7 +39,7 @@ func Validate(ctx context.Context, params ValidateParams) error {
 			Chart:                 chart,
 			Release:               release,
 			Helm:                  params.Helm,
-			NoTagsOnMappingValues: params.NoTagsOnMappingValues,
+			NoTagsOnMappingValues: params.NoValueTags,
 		}
 
 		if err := ValidateRelease(ctx, validateParams); err != nil {

--- a/internal/release/validate/validate_test.go
+++ b/internal/release/validate/validate_test.go
@@ -229,6 +229,10 @@ func TestValidateRelease(t *testing.T) {
 				}
 			}
 
+			if tc.Release.File != nil {
+				require.NoError(t, tc.Release.File.Tree.Decode(tc.Release))
+			}
+
 			err := ValidateRelease(context.Background(), ValidateReleaseParams{
 				Release: tc.Release,
 				Chart:   &helm.ChartFS{FS: tc.ChartFS},

--- a/internal/release/validate/validate_test.go
+++ b/internal/release/validate/validate_test.go
@@ -19,6 +19,12 @@ func TestValidateRelease(t *testing.T) {
 	disallowPullRequest := v1alpha1.Environment{Spec: v1alpha1.EnvironmentSpec{Promotion: v1alpha1.Promotion{FromPullRequests: false}}}
 	allowPullRequest := v1alpha1.Environment{Spec: v1alpha1.EnvironmentSpec{Promotion: v1alpha1.Promotion{FromPullRequests: true}}}
 
+	file := func(data string) *yml.File {
+		file, err := yml.NewFile("./test.yaml", []byte(data))
+		require.NoError(t, err)
+		return file
+	}
+
 	cases := []struct {
 		Name          string
 		Release       *v1alpha1.Release
@@ -28,8 +34,11 @@ func TestValidateRelease(t *testing.T) {
 		SkipReadCalls bool
 	}{
 		{
-			Name:    "spec matches schema",
-			Release: &v1alpha1.Release{Spec: v1alpha1.ReleaseSpec{Values: map[string]any{"hello": "world"}}, Environment: &allowPullRequest},
+			Name: "spec matches schema",
+			Release: &v1alpha1.Release{
+				File:        file("spec: { values: { hello: world } }"),
+				Environment: &allowPullRequest,
+			},
 			ChartFS: &xfs.FSMock{
 				ReadFileFunc: func(string) ([]byte, error) { return []byte(`#values: { hello: string }`), nil },
 				DirNameFunc:  func() string { return "." },
@@ -37,24 +46,34 @@ func TestValidateRelease(t *testing.T) {
 			ExpectedErr: "",
 		},
 		{
-			Name:    "spec does not match schema",
-			Release: &v1alpha1.Release{Spec: v1alpha1.ReleaseSpec{Values: map[string]any{"hello": true}}, Environment: &allowPullRequest},
+			Name: "spec does not match schema",
+			Release: &v1alpha1.Release{
+				File:        file("spec: { values: { hello: true } }"),
+				Environment: &allowPullRequest,
+			},
 			ChartFS: &xfs.FSMock{
 				ReadFileFunc: func(string) ([]byte, error) { return []byte(`#values: { hello: string }`), nil },
+				DirNameFunc:  func() string { return "." },
 			},
 			ExpectedErr: "hydrating values: unifying with chart schema: validating values: #values.hello: conflicting values string and true (mismatched types string and bool)",
 		},
 		{
-			Name:    "values missing from spec",
-			Release: &v1alpha1.Release{Spec: v1alpha1.ReleaseSpec{Values: map[string]any{}}, Environment: &allowPullRequest},
+			Name: "values missing from spec",
+			Release: &v1alpha1.Release{
+				File:        file("spec: { values: { } }"),
+				Environment: &allowPullRequest,
+			},
 			ChartFS: &xfs.FSMock{
 				ReadFileFunc: func(string) ([]byte, error) { return []byte(`#values: { hello: string }`), nil },
 			},
 			ExpectedErr: "hydrating values: unifying with chart schema: validating values: #values.hello: incomplete value string",
 		},
 		{
-			Name:    "multiple errors",
-			Release: &v1alpha1.Release{Spec: v1alpha1.ReleaseSpec{Values: map[string]any{"one": "one", "two": "two"}}, Environment: &allowPullRequest},
+			Name: "multiple errors",
+			Release: &v1alpha1.Release{
+				File:        file("spec: { values: { one: one, two: two } }"),
+				Environment: &allowPullRequest,
+			},
 			ChartFS: &xfs.FSMock{
 				ReadFileFunc: func(string) ([]byte, error) { return []byte(`#values: { one: 1, two: 2 }`), nil },
 			},
@@ -64,8 +83,11 @@ func TestValidateRelease(t *testing.T) {
 				"  - #values.two: conflicting values 2 and \"two\" (mismatched types int and string)",
 		},
 		{
-			Name:    "render fails",
-			Release: &v1alpha1.Release{Spec: v1alpha1.ReleaseSpec{Values: map[string]any{"hello": "world"}}, Environment: &allowPullRequest},
+			Name: "render fails",
+			Release: &v1alpha1.Release{
+				File:        file("spec: { values: { hello: world } }"),
+				Environment: &allowPullRequest,
+			},
 			ChartFS: &xfs.FSMock{
 				ReadFileFunc: func(string) ([]byte, error) { return []byte(`#values: { hello: string }`), nil },
 				DirNameFunc:  func() string { return "" },
@@ -79,8 +101,11 @@ func TestValidateRelease(t *testing.T) {
 			ExpectedErr: "failed to render",
 		},
 		{
-			Name:    "no schema and render fails",
-			Release: &v1alpha1.Release{Spec: v1alpha1.ReleaseSpec{Values: map[string]any{"hello": "world"}}, Environment: &allowPullRequest},
+			Name: "no schema and render fails",
+			Release: &v1alpha1.Release{
+				File:        file("spec: { values: { hello: world } }"),
+				Environment: &allowPullRequest,
+			},
 			ChartFS: &xfs.FSMock{
 				ReadFileFunc: func(string) ([]byte, error) { return nil, os.ErrNotExist },
 				DirNameFunc:  func() string { return "" },
@@ -93,16 +118,23 @@ func TestValidateRelease(t *testing.T) {
 			ExpectedErr: "failed to render",
 		},
 		{
-			Name:    "fail to read schema",
-			Release: &v1alpha1.Release{Spec: v1alpha1.ReleaseSpec{Values: map[string]any{"hello": "world"}}, Environment: &allowPullRequest},
+			Name: "fail to read schema",
+			Release: &v1alpha1.Release{
+				File:        file("spec: { values: { hello: world } }"),
+				Environment: &allowPullRequest,
+			},
 			ChartFS: &xfs.FSMock{
 				ReadFileFunc: func(string) ([]byte, error) { return nil, errors.New("disk corrupted") },
 			},
 			ExpectedErr: "hydrating values: unifying with chart schema: reading values.cue: disk corrupted",
 		},
 		{
-			Name:    "standard version with disallow promotion from pull requests",
-			Release: &v1alpha1.Release{Spec: v1alpha1.ReleaseSpec{Version: "1.0.0", Values: map[string]any{"hello": "world"}}, Environment: &disallowPullRequest, Project: &v1alpha1.Project{Spec: v1alpha1.ProjectSpec{}}},
+			Name: "standard version with disallow promotion from pull requests",
+			Release: &v1alpha1.Release{
+				File:        file("spec: { version: 1.0.0, values: { hello: world } }"),
+				Environment: &disallowPullRequest,
+				Project:     &v1alpha1.Project{Spec: v1alpha1.ProjectSpec{}},
+			},
 			ChartFS: &xfs.FSMock{
 				ReadFileFunc: func(string) ([]byte, error) { return []byte(`#values: { hello: string }`), nil },
 				DirNameFunc:  func() string { return "." },
@@ -110,14 +142,22 @@ func TestValidateRelease(t *testing.T) {
 			ExpectedErr: "",
 		},
 		{
-			Name:          "non-standard version with disallow promotion from pull requests",
-			Release:       &v1alpha1.Release{Spec: v1alpha1.ReleaseSpec{Version: "1.0.0-rc.1+build.1"}, Environment: &disallowPullRequest, Project: &v1alpha1.Project{Spec: v1alpha1.ProjectSpec{}}},
+			Name: "non-standard version with disallow promotion from pull requests",
+			Release: &v1alpha1.Release{
+				Spec:        v1alpha1.ReleaseSpec{Version: "1.0.0-rc.1+build.1"},
+				Environment: &disallowPullRequest,
+				Project:     &v1alpha1.Project{Spec: v1alpha1.ProjectSpec{}},
+			},
 			SkipReadCalls: true,
 			ExpectedErr:   "invalid version: prerelease branches not allowed: 1.0.0-rc.1+build.1",
 		},
 		{
-			Name:    "non-standard version but skip pre-release check",
-			Release: &v1alpha1.Release{Spec: v1alpha1.ReleaseSpec{Version: "2.133.0-pactbroker2.116.0", Values: map[string]any{"hello": "world"}}, Environment: &disallowPullRequest, Project: &v1alpha1.Project{Spec: v1alpha1.ProjectSpec{SkipPreReleaseCheck: true}}},
+			Name: "non-standard version but skip pre-release check",
+			Release: &v1alpha1.Release{
+				File:        file("spec: { version: 2.133.0-pactbroker2.116.0, values: { hello: world } }"),
+				Environment: &disallowPullRequest,
+				Project:     &v1alpha1.Project{Spec: v1alpha1.ProjectSpec{SkipPreReleaseCheck: true}},
+			},
 			ChartFS: &xfs.FSMock{
 				ReadFileFunc: func(string) ([]byte, error) { return []byte(`#values: { hello: string }`), nil },
 				DirNameFunc:  func() string { return "." },
@@ -125,19 +165,23 @@ func TestValidateRelease(t *testing.T) {
 			ExpectedErr: "",
 		},
 		{
-			Name:          "failing values hydration",
-			Release:       &v1alpha1.Release{Spec: v1alpha1.ReleaseSpec{Values: map[string]any{"key": "$ref(.Invalid.Prefix.Ref)"}}, Environment: &v1alpha1.Environment{}, Project: &v1alpha1.Project{Spec: v1alpha1.ProjectSpec{}}},
+			Name: "failing values hydration",
+			Release: &v1alpha1.Release{
+				File:        file("spec: { values: { key: '$ref(.Invalid.Prefix.Ref)' } }"),
+				Environment: &v1alpha1.Environment{},
+				Project:     &v1alpha1.Project{Spec: v1alpha1.ProjectSpec{}},
+			},
 			ChartFS:       &xfs.FSMock{},
 			SkipReadCalls: true,
 			ExpectedErr:   `hydrating values: hydrating object values: only ".Environment.Spec.Values." prefix is supported for object interpolation, but found: .Invalid.Prefix.Ref`,
 		},
 		{
 			Name: "hydrated values matching schema",
-			Release: &v1alpha1.Release{Spec: v1alpha1.ReleaseSpec{Values: map[string]any{"hello": "$ref(.Environment.Spec.Values.hello)"}}, Environment: &v1alpha1.Environment{
-				Spec: v1alpha1.EnvironmentSpec{
-					Values: map[string]any{"hello": "world"},
-				},
-			}, Project: &v1alpha1.Project{Spec: v1alpha1.ProjectSpec{}}},
+			Release: &v1alpha1.Release{
+				File:        file("spec: { values: { hello: '$ref(.Environment.Spec.Values.hello)' } }"),
+				Environment: &v1alpha1.Environment{Spec: v1alpha1.EnvironmentSpec{Values: map[string]any{"hello": "world"}}},
+				Project:     &v1alpha1.Project{Spec: v1alpha1.ProjectSpec{}},
+			},
 			ChartFS: &xfs.FSMock{
 				ReadFileFunc: func(string) ([]byte, error) { return []byte(`#values: { hello: "world" }`), nil },
 				DirNameFunc:  func() string { return "." },
@@ -146,11 +190,11 @@ func TestValidateRelease(t *testing.T) {
 		},
 		{
 			Name: "hydrated values not matching schema",
-			Release: &v1alpha1.Release{Spec: v1alpha1.ReleaseSpec{Values: map[string]any{"hello": "$ref(.Environment.Spec.Values.hello)"}}, Environment: &v1alpha1.Environment{
-				Spec: v1alpha1.EnvironmentSpec{
-					Values: map[string]any{"hello": "narnia"},
-				},
-			}, Project: &v1alpha1.Project{Spec: v1alpha1.ProjectSpec{}}},
+			Release: &v1alpha1.Release{
+				File:        file("spec: { values: { hello: '$ref(.Environment.Spec.Values.hello)' } }"),
+				Environment: &v1alpha1.Environment{Spec: v1alpha1.EnvironmentSpec{Values: map[string]any{"hello": "narnia"}}},
+				Project:     &v1alpha1.Project{Spec: v1alpha1.ProjectSpec{}},
+			},
 			ChartFS: &xfs.FSMock{
 				ReadFileFunc: func(string) ([]byte, error) { return []byte(`#values: { hello: "world" }`), nil },
 				DirNameFunc:  func() string { return "." },
@@ -162,11 +206,7 @@ func TestValidateRelease(t *testing.T) {
 			Release: &v1alpha1.Release{
 				Environment: &v1alpha1.Environment{},
 				Project:     &v1alpha1.Project{Spec: v1alpha1.ProjectSpec{}},
-				File: &yml.File{Tree: func() *yaml.Node {
-					var node yaml.Node
-					_ = yaml.Unmarshal([]byte(`{ value: !lock TODO }`), &node)
-					return &node
-				}()},
+				File:        file("{ value: !lock TODO }"),
 			},
 			ExpectedErr:   "contains locked TODO",
 			SkipReadCalls: true,

--- a/internal/yml/find_node.go
+++ b/internal/yml/find_node.go
@@ -10,20 +10,30 @@ import (
 // FindNode traverses a given yaml.Node to locate the value Node of the provided path. The path is interpreted as being
 // relative to the given yaml.Node.
 func FindNode(node *yaml.Node, path string) (resultNode *yaml.Node, err error) {
+	keypair, err := FindNodeKeyPair(node, path)
+	if err != nil {
+		return nil, err
+	}
+	return keypair.Value, nil
+}
+
+// FindNodeKeyPair traverses a given yaml.Node to locate the value Node of the provided path. The path is interpreted as being
+// relative to the given yaml.Node.
+func FindNodeKeyPair(node *yaml.Node, path string) (keypair *KeyValuePair, err error) {
 	var findNodeErr error
 
 	// If node is a DocumentNode, we need to retrieve the MappingNode from its Content and traverse it.
 	if node.Kind == yaml.DocumentNode && len(node.Content) == 1 {
-		resultNode, findNodeErr = findNode(node.Content[0], segmentPath(path))
+		keypair, findNodeErr = findKeypair(node.Content[0], segmentPath(path))
 	} else {
-		resultNode, findNodeErr = findNode(node, segmentPath(path))
+		keypair, findNodeErr = findKeypair(node, segmentPath(path))
 	}
 
 	if findNodeErr != nil {
 		return nil, fmt.Errorf("node not found for path '%s': %w", path, findNodeErr)
 	}
 
-	return resultNode, nil
+	return keypair, nil
 }
 
 func FindNodeValueOrDefault(node *yaml.Node, path string, defaultValue string) string {
@@ -95,7 +105,7 @@ func setOrAddNodeValue(node *yaml.Node, pathSegments []string, value string) err
 	return nil
 }
 
-func findNode(node *yaml.Node, pathSegments []string) (*yaml.Node, error) {
+func findKeypair(node *yaml.Node, pathSegments []string) (*KeyValuePair, error) {
 	// Condition is i+1 < len(node.Content) as there always need to be at least 2 entries left in the node.Content for
 	// traversal to work, because each key and its associated value are stored in two consecutive nodes in the slice.
 	for i := 0; i+1 < len(node.Content); i += 2 {
@@ -107,12 +117,12 @@ func findNode(node *yaml.Node, pathSegments []string) (*yaml.Node, error) {
 		if keyNode.Value == pathSegments[0] {
 			// If there is only 1 segment left in pathSegments, then this is the droid we are looking for.
 			if len(pathSegments) == 1 {
-				return valueNode, nil
+				return &KeyValuePair{Key: keyNode, Value: valueNode}, nil
 			}
 
 			// MappingNodes contain more key/value pairings, so we'll recurse into the next level of the path to search.
 			if valueNode.Kind == yaml.MappingNode {
-				return findNode(valueNode, pathSegments[1:])
+				return findKeypair(valueNode, pathSegments[1:])
 			}
 		}
 	}

--- a/internal/yml/merge.go
+++ b/internal/yml/merge.go
@@ -33,6 +33,7 @@ func Merge(dst, src *yaml.Node, sameOrg bool) *yaml.Node {
 	if result == nil {
 		result = &yaml.Node{Kind: yaml.MappingNode}
 	}
+	purgeMapingValueCustomTagsFromKeys(result)
 
 	doc.Content = []*yaml.Node{result}
 	return doc
@@ -263,4 +264,23 @@ func purgeNodes(node *yaml.Node, predicate func(*yaml.Node) bool) *yaml.Node {
 	}
 
 	return &copy
+}
+
+// purgeMapingValueCustomTags removes tags for values within mapping nodes if we can detect that
+// the tag was inherited from its key node during merge.
+func purgeMapingValueCustomTagsFromKeys(node *yaml.Node) {
+	if node.Kind == yaml.MappingNode {
+		for i := 0; i < len(node.Content); i += 2 {
+			var (
+				key   = node.Content[i]
+				value = node.Content[i+1]
+			)
+			if slices.Contains(CustomTags, value.Tag) && key.Tag == value.Tag {
+				value.Tag = ""
+			}
+		}
+	}
+	for _, node := range node.Content {
+		purgeMapingValueCustomTagsFromKeys(node)
+	}
 }

--- a/internal/yml/merge.go
+++ b/internal/yml/merge.go
@@ -1,6 +1,8 @@
 package yml
 
 import (
+	"slices"
+
 	"gopkg.in/yaml.v3"
 )
 
@@ -178,10 +180,14 @@ type KeyValuePair struct {
 func asMap(node *yaml.Node) map[string]KeyValuePair {
 	result := make(map[string]KeyValuePair, len(node.Content)/2)
 	for i := 0; i < len(node.Content); i += 2 {
-		result[node.Content[i].Value] = KeyValuePair{
+		kv := KeyValuePair{
 			Key:   node.Content[i],
 			Value: node.Content[i+1],
 		}
+		if slices.Contains(CustomTags, kv.Key.Tag) {
+			kv.Value.Tag = kv.Key.Tag
+		}
+		result[node.Content[i].Value] = kv
 	}
 	return result
 }
@@ -242,7 +248,7 @@ func purgeNodes(node *yaml.Node, predicate func(*yaml.Node) bool) *yaml.Node {
 	switch node.Kind {
 	case yaml.MappingNode:
 		for i := 0; i < len(node.Content); i += 2 {
-			if predicate(node.Content[i+1]) {
+			if predicate(node.Content[i]) || predicate(node.Content[i+1]) {
 				continue
 			}
 			copy.Content = append(copy.Content, node.Content[i], purgeNodes(node.Content[i+1], predicate))

--- a/internal/yml/merge.go
+++ b/internal/yml/merge.go
@@ -153,8 +153,12 @@ func markLockedValuesAsTodo(node *yaml.Node, locked bool) *yaml.Node {
 			node.Content[i] = markLockedValuesAsTodo(n, locked)
 		}
 	case yaml.MappingNode:
-		for i := 1; i < len(node.Content); i += 2 {
-			node.Content[i] = markLockedValuesAsTodo(node.Content[i], locked)
+		for i := 0; i < len(node.Content); i += 2 {
+			var (
+				key   = node.Content[i]
+				value = node.Content[i+1]
+			)
+			node.Content[i+1] = markLockedValuesAsTodo(value, locked || IsLocked(key))
 		}
 	}
 

--- a/internal/yml/merge_test.go
+++ b/internal/yml/merge_test.go
@@ -750,7 +750,7 @@ func TestYmlMerge(t *testing.T) {
 			Expected: "{!lock key: TODO}",
 		},
 		{
-			Name:     "lcoal on key nodes",
+			Name:     "local on key nodes",
 			Src:      "{ !local key: value }",
 			Dst:      "{!lock foo: bar}",
 			Expected: "{!lock foo: bar}",

--- a/internal/yml/merge_test.go
+++ b/internal/yml/merge_test.go
@@ -743,6 +743,24 @@ func TestYmlMerge(t *testing.T) {
 			Dst:      "{}",
 			Expected: "{outer: {}}",
 		},
+		{
+			Name:     "locks on key nodes",
+			Src:      "{ !lock key: value }",
+			Dst:      "{}",
+			Expected: "{!lock key: TODO}",
+		},
+		{
+			Name:     "lcoal on key nodes",
+			Src:      "{ !local key: value }",
+			Dst:      "{!lock foo: bar}",
+			Expected: "{!lock foo: bar}",
+		},
+		{
+			Name:     "remove duplicate tags",
+			Src:      "{ !lock key: !lock value }",
+			Dst:      "{}",
+			Expected: "{!lock key: TODO}",
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/yml/todos.go
+++ b/internal/yml/todos.go
@@ -42,7 +42,7 @@ func GetMappingValueNodesWithTags(node *yaml.Node) (nodes []*yaml.Node) {
 	if node.Kind == yaml.MappingNode {
 		for i := 1; i < len(node.Content); i += 2 {
 			value := node.Content[i]
-			if slices.Contains(CustomTags, node.Tag) {
+			if slices.Contains(CustomTags, value.Tag) {
 				nodes = append(nodes, value)
 			}
 		}

--- a/internal/yml/todos.go
+++ b/internal/yml/todos.go
@@ -14,7 +14,18 @@ func hasLockedTodos(node *yaml.Node, locked bool) bool {
 	locked = locked || IsLocked(node)
 
 	switch node.Kind {
-	case yaml.DocumentNode, yaml.MappingNode, yaml.SequenceNode:
+	case yaml.MappingNode:
+		for i := 0; i < len(node.Content); i += 2 {
+			var (
+				key   = node.Content[i]
+				value = node.Content[i+1]
+			)
+			if hasLockedTodos(value, locked || IsLocked(key)) {
+				return true
+			}
+		}
+		return false
+	case yaml.DocumentNode, yaml.SequenceNode:
 		for _, n := range node.Content {
 			if hasLockedTodos(n, locked) {
 				return true

--- a/internal/yml/todos.go
+++ b/internal/yml/todos.go
@@ -1,6 +1,10 @@
 package yml
 
-import "gopkg.in/yaml.v3"
+import (
+	"slices"
+
+	"gopkg.in/yaml.v3"
+)
 
 func HasLockedTodos(node *yaml.Node) bool {
 	return hasLockedTodos(node, false)
@@ -21,4 +25,19 @@ func hasLockedTodos(node *yaml.Node, locked bool) bool {
 	default:
 		return locked && node.Value == "TODO"
 	}
+}
+
+func GetMappingValueNodesWithTags(node *yaml.Node) (nodes []*yaml.Node) {
+	if node.Kind == yaml.MappingNode {
+		for i := 1; i < len(node.Content); i += 2 {
+			value := node.Content[i]
+			if slices.Contains(CustomTags, node.Tag) {
+				nodes = append(nodes, value)
+			}
+		}
+	}
+	for _, node := range node.Content {
+		nodes = append(nodes, GetMappingValueNodesWithTags(node)...)
+	}
+	return
 }

--- a/internal/yml/todos_test.go
+++ b/internal/yml/todos_test.go
@@ -65,6 +65,11 @@ func TestHasLockedTodos(t *testing.T) {
 			Value:    "{top: !lock { middle: { bottom: TODO } } }",
 			Expected: true,
 		},
+		{
+			Name:     "keyed lock todo",
+			Value:    "{ mapping: { !lock key: TODO } }",
+			Expected: true,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Joy uses tags as promotion directives when promoting releases across environments.

These tags have worked generally well for us but have come with one drawback: tags are used to store type information and parsing directives for standard yaml parsers.

When we would add a custom tag to a scalar node, it would lose its type information, and fallback to being interpreted as a string.

Hence:

```yaml
--- release yaml
key: !lock true
--- parsed yaml
key: "true" // not the boolean true.
```

This has always been at odds with out strict schema/cue unification, making sure that developers are writing the correct and desired values for the underlying release's chart.

We've managed to get around this by having joy strip custom tags when unmarshalling releases and by always having joy in the hot-path of any integration. For example the joy-generator would maintain its own local copy of the catalog to load it and recompute all values.

Now that we are moving towards the joy-operator, argocd will be responsible for syncing our catalog resources. This means that joy is no longer responsible for parsing the files, and our tags as promotion directives gets in the way of proper yaml parsing.

To mitigate this, we can move the custom tagging to the key node of a given value instead of on the node itself.

This works because keys should always be strings. (Not always the case in yaml, but always the case with kubernetes APIs). 

This doesn't mitigate the issue completely in theory, as sequence nodes can still fall prey to this issue.
However in practice this has yet to occur.

Regardless, this PR also changes the rendering logic to use the release yaml instead of the custom-parsed release, meaning that we can catch these issues ahead of time.

It also adds a new flag during validation to disalllow custom tags on value nodes within a mapping.

It also ships with a tag migrator. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core promotion merge/lock semantics and how releases are decoded for render/validate; the tag migrator overwrites release files on disk if run.
> 
> **Overview**
> Promotion directives (`!lock`, `!local`, etc.) are moving from **mapping values to mapping keys** so release YAML stays valid for standard parsers (e.g. Argo CD) without scalars losing boolean/number types.
> 
> **YAML & promotion behavior** is updated end-to-end: merge propagates tags from keys to values internally then strips duplicate value tags on output; locked/TODO detection and local purging respect tags on keys; `FindNodeKeyPair` and version promotion treat `spec.version` as locked when either the key or value is locked.
> 
> **Validate & render** gain `--no-value-tags` (reject legacy tags on values) and `--raw-yaml` (hydrate/render from the on-disk tree via new `Release.FromTree()` instead of tag-stripped unmarshaling).
> 
> A **`cmd/tag-migrator`** utility rewrites the loaded catalog in place, moving supported custom tags from values onto their keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70070b8e41255625d6139c30652ff9a332f5d433. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `joy release validate` flags for rejecting tags on mapping values and for validating against raw YAML.
  - Added a tag-migration CLI to move supported YAML tags from mapping values to their keys.
- **Bug Fixes**
  - Improved rendering/validation to hydrate values from the parsed release tree (including when using raw YAML).
  - Fixed YAML merge behavior to properly purge mapping-value custom tags and preserve lock/TODO semantics.
  - Promotion now skips updating `spec.version` when it’s locked.
- **Tests**
  - Expanded validation, rendering, merge, and TODO/lock test coverage for keyed tagged mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->