### PR TITLE
feat(PL-6895): add raw yaml flag to releaser render command

### DIFF
--- a/cmd/joy/release.go
+++ b/cmd/joy/release.go
@@ -325,6 +325,7 @@ func NewReleaseRenderCmd() *cobra.Command {
 		valuesOnly   bool
 		normalize    bool
 		debug        bool
+		useRawYaml   bool
 	)
 
 	cmd := &cobra.Command{
@@ -505,6 +506,7 @@ func NewReleaseRenderCmd() *cobra.Command {
 							Chart:      chart,
 							Helm:       helm.CLI{IO: internal.IoFromCommand(cmd), Debug: debug},
 							ValuesOnly: valuesOnly,
+							UseRawYaml: useRawYaml,
 						}
 
 						result, err := render.Render(cmd.Context(), params)
@@ -628,6 +630,7 @@ func NewReleaseRenderCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&valuesOnly, "values", false, "print rendered chart values only")
 	cmd.Flags().BoolVar(&debug, "debug", false, "send the --debug flag to the helm cli")
 	cmd.Flags().BoolVar(&normalize, "normalize", false, "decodes and re-encodes the rendered yaml into a normalized format so that templating diffs are ignored")
+	cmd.Flags().BoolVar(&useRawYaml, "raw-yaml", false, "use raw release yaml instead of joy parsed releases for rendering")
 
 	return cmd
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small CLI wiring change that reuses existing render logic already used by validate; default behavior is unchanged.
> 
> **Overview**
> Adds **`--raw-yaml`** to **`joy release render`**, matching **`release validate`**.
> 
> When set, rendering passes **`UseRawYaml`** into **`render.Render`**, which builds the release from the on-disk file tree via **`FromTree()`** instead of the Joy-parsed release object—useful when you want manifests that reflect raw catalog YAML rather than normalized in-memory structures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8913157c03a076010d12730167003cbf119a628. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->