### PR TITLE
fix(PL-6895): remove edge case when merging mapping keys to preserve comments and tags

### DIFF
--- a/internal/yml/merge.go
+++ b/internal/yml/merge.go
@@ -75,7 +75,7 @@ func mergeMap(dst, src *yaml.Node) *yaml.Node {
 	for _, key := range keys {
 		dstKV, srcKV := dstMap[key], srcMap[key]
 		if value := merge(dstKV.Value, srcKV.Value); value != nil {
-			content = append(content, firstNonNil(dstKV.Key, srcKV.Key), value)
+			content = append(content, mergeKey(dstKV.Key, srcKV.Key), value)
 		}
 	}
 
@@ -83,6 +83,17 @@ func mergeMap(dst, src *yaml.Node) *yaml.Node {
 	dst.Style = mergeStyle(dst.Style, src.Style)
 
 	return dst
+}
+
+func mergeKey(dst, src *yaml.Node) *yaml.Node {
+	if IsLocked(dst) || IsLocal(dst) || src == nil {
+		return dst
+	}
+	if dst != nil {
+		// we want to preserve comments within destination files.
+		src.HeadComment = dst.HeadComment
+	}
+	return src
 }
 
 func mergeSeq(dst, src *yaml.Node) *yaml.Node {
@@ -223,15 +234,6 @@ func mergeStyle(dst, src yaml.Style) yaml.Style {
 		dst &^= yaml.FlowStyle
 	}
 	return dst
-}
-
-func firstNonNil(nodes ...*yaml.Node) *yaml.Node {
-	for _, node := range nodes {
-		if node != nil {
-			return node
-		}
-	}
-	return nil
 }
 
 func purgeLocalContent(node *yaml.Node) *yaml.Node {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized change to YAML merge key selection with no auth, security, or external API impact.
> 
> **Overview**
> **YAML map merges** now pick mapping keys through a dedicated `mergeKey` helper instead of `firstNonNil`, fixing edge cases when destination and source keys differ (comments, tags, or missing keys).
> 
> When the destination key is **locked** or **local**, or the source key is absent, the merge keeps the destination key node. Otherwise it uses the source key but copies the destination key’s `HeadComment` onto it so inline comments on keys survive the merge.
> 
> The unused `firstNonNil` helper is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db6dac16f8d27b775cab38a297f26971e862a9c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YAML merge behavior by selecting merge keys more reliably when both sides contain mergable values.
  * Preserves destination lock/local semantics so locked/local destination keys remain unchanged.
  * Better handles cases where the source key is nil and preserves head comments during the merge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->