### PR TITLE
feat(PL-6299): use sigs yaml for release parsing

### DIFF
--- a/api/v1alpha1/release.go
+++ b/api/v1alpha1/release.go
@@ -7,6 +7,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	sigsyaml "sigs.k8s.io/yaml"
 
 	"github.com/nestoca/joy/internal"
 	"github.com/nestoca/joy/internal/yml"
@@ -115,8 +116,13 @@ func IsValidRelease(apiVersion, kind string) bool {
 
 // LoadRelease loads a release from the given release file.
 func LoadRelease(file *yml.File) (*Release, error) {
+	data, err := yaml.Marshal(stripCustomTags(yml.Clone(file.Tree)))
+	if err != nil {
+		return nil, fmt.Errorf("marshalling release stripped of custom tags")
+	}
+
 	var rel Release
-	if err := yml.UnmarshalStrict(file.Yaml, &rel); err != nil {
+	if err := sigsyaml.UnmarshalStrict(data, &rel); err != nil {
 		return nil, fmt.Errorf("unmarshalling release: %w", err)
 	}
 	rel.File = file

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	gopkg.in/godo.v2 v2.0.9
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apimachinery v0.36.1
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (


### PR DESCRIPTION
This PR introduces `sigs.k8s.io/yaml` which does json interop with yaml properly. With the tags on keys this would confuse yaml/v3 into creating go values of type `map[any]any` which is not json parsable and would break the generator.

This will allow us to update the generator with this new version of joy and be compatible with the new catalog tag format.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all catalog releases are parsed at load time; mis-handling of custom tags or strict unknown-field rejection could break catalog loading or generator compatibility.
> 
> **Overview**
> **Release loading** now round-trips the YAML AST through **custom-tag stripping**, re-marshals with `gopkg.in/yaml.v3`, and unmarshals with **`sigs.k8s.io/yaml` strict parsing** instead of the internal `yml.UnmarshalStrict` path on the raw file.
> 
> This avoids **`map[any]any`** values when catalog keys carry custom YAML tags, so release data stays **JSON-compatible** for downstream generator use with the new catalog tag format.
> 
> Adds **`sigs.k8s.io/yaml v1.6.0`** as a direct module dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f83a2b9d3c7efc90cba6941a6ee8b2eed7ce6029. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release YAML loading to use consistent strict parsing behavior.
  * Custom tags are handled more reliably before strict decoding, ensuring unknown or unsupported fields are consistently rejected during release loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->