### PR TITLE
feat(PL-5900): promote build exclude label flag for front-end previews

### DIFF
--- a/cmd/joy/build.go
+++ b/cmd/joy/build.go
@@ -21,7 +21,10 @@ func NewBuildCmd() *cobra.Command {
 }
 
 func NewBuildPromoteCmd() *cobra.Command {
-	var chartVersion string
+	var (
+		chartVersion  string
+		excludeLabels []string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "promote",
@@ -29,7 +32,7 @@ func NewBuildPromoteCmd() *cobra.Command {
 		Long: `Promote a project to given version in given environment.
 Typically called at the end of a CI pipeline to promote a new build to default target environment.
 
-Usage: joy build promote [--chart-version <chart-version>] <env> <project> <version>`,
+Usage: joy build promote [--chart-version <chart-version>] [--exclude-label <key[=value]>]... <env> <project> <version>`,
 		Args: cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			env := args[0]
@@ -40,17 +43,19 @@ Usage: joy build promote [--chart-version <chart-version>] <env> <project> <vers
 			cat.WithEnvironments([]string{env})
 
 			return build.Promote(build.Opts{
-				Catalog:      cat,
-				Environment:  env,
-				Project:      project,
-				Version:      version,
-				Writer:       yml.DiskWriter,
-				ChartVersion: chartVersion,
+				Catalog:       cat,
+				Environment:   env,
+				Project:       project,
+				Version:       version,
+				Writer:        yml.DiskWriter,
+				ChartVersion:  chartVersion,
+				ExcludeLabels: excludeLabels,
 			})
 		},
 	}
 
 	cmd.Flags().StringVar(&chartVersion, "chart-version", "", "(optional) Chart version to promote")
+	cmd.Flags().StringArrayVar(&excludeLabels, "exclude-label", nil, "(optional, repeatable) Skip releases carrying this metadata label. Format: `key` or `key=value`; a bare key matches any value (e.g. --exclude-label nesto.ca/preview)")
 
 	return cmd
 }

--- a/internal/build/promote.go
+++ b/internal/build/promote.go
@@ -6,6 +6,7 @@ import (
 	"golang.org/x/mod/semver"
 
 	"github.com/nestoca/joy/api/v1alpha1"
+	"github.com/nestoca/joy/internal/labels"
 	"github.com/nestoca/joy/internal/style"
 	"github.com/nestoca/joy/internal/yml"
 	"github.com/nestoca/joy/pkg/catalog"
@@ -18,6 +19,10 @@ type Opts struct {
 	Project      string
 	Version      string
 	ChartVersion string
+
+	// ExcludeLabels are `key` or `key=value` selectors; a release carrying any matching
+	// metadata label is skipped. A bare `key` matches the label regardless of its value.
+	ExcludeLabels []string
 }
 
 func Promote(opts Opts) error {
@@ -26,6 +31,11 @@ func Promote(opts Opts) error {
 		if semver.Prerelease(version)+semver.Build(version) != "" {
 			return fmt.Errorf("cannot promote prerelease version to %s environment", opts.Environment)
 		}
+	}
+
+	excludeSelectors, err := labels.ParseSelectors(opts.ExcludeLabels)
+	if err != nil {
+		return fmt.Errorf("parsing exclude labels: %w", err)
 	}
 
 	var releases []*v1alpha1.Release
@@ -43,6 +53,11 @@ func Promote(opts Opts) error {
 
 	promotionCount := 0
 	for _, release := range releases {
+		if selector, ok := labels.FirstMatch(excludeSelectors, release.Labels); ok {
+			fmt.Printf("⚠️ Skipping promotion of release %s: excluded by label %s\n", style.Resource(release.Name), style.Code(selector.String()))
+			continue
+		}
+
 		versionKeypair, err := yml.FindNodeKeyPair(release.File.Tree, "spec.version")
 		if err != nil {
 			return fmt.Errorf("release %s has no version property: %w", release.Name, err)

--- a/internal/build/promote_test.go
+++ b/internal/build/promote_test.go
@@ -106,6 +106,41 @@ func TestPromoteWhenNoReleasesFoundForProject(t *testing.T) {
 	require.EqualError(t, Promote(opts), "no releases found for project promote-build")
 }
 
+func TestPromoteExcludesLabeledReleases(t *testing.T) {
+	var writer yml.WriterMock
+
+	environments := []*v1alpha1.Environment{{EnvironmentMetadata: v1alpha1.EnvironmentMetadata{ObjectMeta: metav1.ObjectMeta{Name: "staging"}}}}
+	release := func(name string, labels map[string]string) *cross.Release {
+		return &cross.Release{Releases: []*v1alpha1.Release{{
+			ReleaseMetadata: v1alpha1.ReleaseMetadata{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels}},
+			Spec:            v1alpha1.ReleaseSpec{Project: "promote-build"},
+			File:            makeFile(t, "{ spec: { version: 0.0.0 } }"),
+		}}}
+	}
+	opts := Opts{
+		Catalog: &catalog.Catalog{
+			Environments: environments,
+			Releases: cross.ReleaseList{
+				Environments: environments,
+				Items: []*cross.Release{
+					release("regular", nil),
+					release("preview", map[string]string{"nesto.ca/preview": "true"}),
+				},
+			},
+		},
+		Environment:   "staging",
+		Writer:        &writer,
+		Project:       "promote-build",
+		Version:       "1.1.2",
+		ExcludeLabels: []string{"nesto.ca/preview"},
+	}
+
+	require.NoError(t, Promote(opts))
+	// Only the unlabeled "regular" release is promoted; "preview" is excluded.
+	require.Len(t, writer.WriteFileCalls(), 1)
+	require.Equal(t, "1.1.2", yml.FindNodeValueOrDefault(writer.WriteFileCalls()[0].File.Tree, "spec.version", ""))
+}
+
 func makeFile(t *testing.T, content string) *yml.File {
 	t.Helper()
 	f, err := yml.NewFile("", []byte(content))

--- a/internal/labels/labels.go
+++ b/internal/labels/labels.go
@@ -1,0 +1,55 @@
+// Package labels matches Kubernetes-style metadata labels via `key` / `key=value` selectors.
+package labels
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Selector matches a metadata label by key, and optionally by exact value.
+type Selector struct {
+	key      string
+	value    string
+	hasValue bool
+}
+
+func (s Selector) String() string {
+	if s.hasValue {
+		return s.key + "=" + s.value
+	}
+	return s.key
+}
+
+// matches reports whether labelSet contains this selector's key (and, when a value is
+// specified, that it equals that value).
+func (s Selector) matches(labelSet map[string]string) bool {
+	value, ok := labelSet[s.key]
+	if !ok {
+		return false
+	}
+	return !s.hasValue || value == s.value
+}
+
+// ParseSelectors parses `key` / `key=value` specs into selectors. A bare `key` matches the
+// label regardless of its value; `key=value` requires an exact match. An empty key is rejected.
+func ParseSelectors(specs []string) ([]Selector, error) {
+	selectors := make([]Selector, 0, len(specs))
+	for _, spec := range specs {
+		key, value, hasValue := strings.Cut(spec, "=")
+		if strings.TrimSpace(key) == "" {
+			return nil, fmt.Errorf("invalid label selector %q: key is empty", spec)
+		}
+		selectors = append(selectors, Selector{key: key, value: value, hasValue: hasValue})
+	}
+	return selectors, nil
+}
+
+// FirstMatch returns the first selector matching the given label set, if any.
+func FirstMatch(selectors []Selector, labelSet map[string]string) (Selector, bool) {
+	for _, selector := range selectors {
+		if selector.matches(labelSet) {
+			return selector, true
+		}
+	}
+	return Selector{}, false
+}

--- a/internal/labels/labels.go
+++ b/internal/labels/labels.go
@@ -36,7 +36,10 @@ func ParseSelectors(specs []string) ([]Selector, error) {
 	selectors := make([]Selector, 0, len(specs))
 	for _, spec := range specs {
 		key, value, hasValue := strings.Cut(spec, "=")
-		if strings.TrimSpace(key) == "" {
+		// Trim surrounding whitespace so a padded key (e.g. " nesto.ca/preview") still
+		// matches the actual metadata key rather than silently never matching.
+		key = strings.TrimSpace(key)
+		if key == "" {
 			return nil, fmt.Errorf("invalid label selector %q: key is empty", spec)
 		}
 		selectors = append(selectors, Selector{key: key, value: value, hasValue: hasValue})

--- a/internal/labels/labels_test.go
+++ b/internal/labels/labels_test.go
@@ -7,13 +7,19 @@ import (
 )
 
 func TestParseSelectors(t *testing.T) {
-	sels, err := ParseSelectors([]string{"bare", "k=v", "empty="})
+	sels, err := ParseSelectors([]string{"bare", "k=v", "empty=", "  spaced  "})
 	require.NoError(t, err)
 	require.Equal(t, []Selector{
 		{key: "bare"},
 		{key: "k", value: "v", hasValue: true},
 		{key: "empty", value: "", hasValue: true},
+		{key: "spaced"}, // surrounding whitespace is trimmed off the key
 	}, sels)
+
+	// A padded key still matches the real metadata key.
+	got, ok := FirstMatch(sels, map[string]string{"spaced": "x"})
+	require.True(t, ok)
+	require.Equal(t, "spaced", got.String())
 
 	for _, bad := range []string{"", "=novalue", "   "} {
 		_, err := ParseSelectors([]string{bad})

--- a/internal/labels/labels_test.go
+++ b/internal/labels/labels_test.go
@@ -1,0 +1,46 @@
+package labels
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSelectors(t *testing.T) {
+	sels, err := ParseSelectors([]string{"bare", "k=v", "empty="})
+	require.NoError(t, err)
+	require.Equal(t, []Selector{
+		{key: "bare"},
+		{key: "k", value: "v", hasValue: true},
+		{key: "empty", value: "", hasValue: true},
+	}, sels)
+
+	for _, bad := range []string{"", "=novalue", "   "} {
+		_, err := ParseSelectors([]string{bad})
+		require.Error(t, err, "selector %q should be rejected", bad)
+	}
+}
+
+func TestSelectorMatches(t *testing.T) {
+	// Bare key matches regardless of value (including empty), and misses when absent.
+	require.True(t, Selector{key: "a"}.matches(map[string]string{"a": "anything"}))
+	require.True(t, Selector{key: "a"}.matches(map[string]string{"a": ""}))
+	require.False(t, Selector{key: "a"}.matches(map[string]string{"other": "x"}))
+	require.False(t, Selector{key: "a"}.matches(nil))
+
+	// key=value requires an exact match.
+	require.True(t, Selector{key: "a", value: "1", hasValue: true}.matches(map[string]string{"a": "1"}))
+	require.False(t, Selector{key: "a", value: "1", hasValue: true}.matches(map[string]string{"a": "2"}))
+}
+
+func TestFirstMatch(t *testing.T) {
+	selectors, err := ParseSelectors([]string{"nesto.ca/preview", "team=fe"})
+	require.NoError(t, err)
+
+	got, ok := FirstMatch(selectors, map[string]string{"nesto.ca/preview": "true"})
+	require.True(t, ok)
+	require.Equal(t, "nesto.ca/preview", got.String())
+
+	_, ok = FirstMatch(selectors, map[string]string{"unrelated": "x"})
+	require.False(t, ok)
+}


### PR DESCRIPTION
## What

Add `--exclude-label` to `joy build promote` to skip releases carrying a given metadata label.

Example:
```
joy build promote --exclude-label nesto.ca/preview staging backoffice 1.2.3
```

## Why

Frontend previews (PL-5900) create a preview release copy with label `nesto.ca/preview: "true"`.

Without this flag, a normal project promotion overwrites those preview release versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `joy build promote` support for excluding releases via a repeatable `--exclude-label <key[=value]>` option.
  * Label selectors support both key-only and exact `key=value` matching.
  * Skipped releases now emit a warning, and promotion reports if no releases were promoted after exclusions.
* **Bug Fixes**
  * Added validation and clear errors for invalid label selector formats.
* **Tests**
  * Added unit coverage for excluding labeled releases during promotion and for selector parsing/matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->