### PR TITLE
feat(PL-5900): create/update/delete preview release

### DIFF
--- a/api/v1alpha1/scheme.go
+++ b/api/v1alpha1/scheme.go
@@ -13,6 +13,10 @@ const (
 	CatalogKind     = "Catalog"
 )
 
+// PreviewLabel marks a release as a preview copy created by `joy release preview`.
+// `joy build promote` always excludes releases carrying this label.
+const PreviewLabel = "joy.nesto.ca/preview"
+
 var GroupVersion = schema.GroupVersion{Group: Group, Version: Version}
 
 var (

--- a/cmd/joy/release.go
+++ b/cmd/joy/release.go
@@ -56,6 +56,7 @@ func NewReleaseCmd(preRunConfigs PreRunConfigs) *cobra.Command {
 	cmd.AddCommand(NewReleaseOpenCmd())
 	cmd.AddCommand(NewReleaseLinksCmd())
 	cmd.AddCommand(NewReleaseSchemaCmd())
+	cmd.AddCommand(NewReleasePreviewCmd())
 	cmd.AddCommand(NewGitCommands())
 	cmd.AddCommand(NewValidateCommand())
 

--- a/cmd/joy/release_preview.go
+++ b/cmd/joy/release_preview.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/nestoca/joy/internal/patch"
+	"github.com/nestoca/joy/internal/preview"
+	"github.com/nestoca/joy/internal/yml"
+	"github.com/nestoca/joy/pkg/catalog"
+)
+
+func NewReleasePreviewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "preview",
+		Short: "Create or delete preview copies of a release",
+		Long: `Manage preview copies of a release within an environment.
+
+A preview is a copy of a source release named <release><suffix>, pinned to a version and
+labelled ` + "`joy.nesto.ca/preview`" + ` so that "joy build promote" excludes it. Callers layer
+their own transforms via repeatable --patch (RFC 6902 op) and --replace (regex) flags.`,
+	}
+	cmd.AddCommand(newReleasePreviewCreateCmd())
+	cmd.AddCommand(newReleasePreviewDeleteCmd())
+	return cmd
+}
+
+func newReleasePreviewCreateCmd() *cobra.Command {
+	var (
+		env      string
+		suffix   string
+		version  string
+		patches  []string
+		replaces []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create -e <env> <release> --suffix <suffix> --version <version>",
+		Short: "Create or update a preview copy of a release",
+		Long: `Create a preview copy of <release> named <release><suffix> in the given environment.
+
+Applies, in order: built-ins (metadata.name, joy.nesto.ca/preview label, spec.version), then
+each --patch, then each --replace, then a final placeholder pass (__RELEASE__, __SUFFIX__).
+If the preview already exists, only spec.version is updated.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ops, err := parsePatchFlags(patches)
+			if err != nil {
+				return err
+			}
+			replacements, err := parseReplaceFlags(replaces)
+			if err != nil {
+				return err
+			}
+
+			cat := catalog.FromContext(cmd.Context())
+			cat.WithEnvironments([]string{env})
+
+			return preview.Create(preview.CreateParams{
+				Catalog:  cat,
+				Writer:   yml.DiskWriter,
+				Env:      env,
+				Release:  args[0],
+				Suffix:   suffix,
+				Version:  version,
+				Patches:  ops,
+				Replaces: replacements,
+			})
+		},
+	}
+
+	cmd.Flags().StringVarP(&env, "env", "e", "", "Environment of the source release")
+	cmd.Flags().StringVar(&suffix, "suffix", "", "Suffix appended to the release name to form the preview (include the leading dash, e.g. -og-1234)")
+	cmd.Flags().StringVar(&version, "version", "", "Version to set on the preview release")
+	cmd.Flags().StringArrayVar(&patches, "patch", nil, "(repeatable) A single RFC 6902 op (add/replace/remove) applied to the preview, as JSON/YAML")
+	cmd.Flags().StringArrayVar(&replaces, "replace", nil, "(repeatable) A single {search, replace} regex applied to the preview file text, as JSON/YAML")
+	_ = cmd.MarkFlagRequired("env")
+	_ = cmd.MarkFlagRequired("suffix")
+	_ = cmd.MarkFlagRequired("version")
+
+	return cmd
+}
+
+func newReleasePreviewDeleteCmd() *cobra.Command {
+	var (
+		env    string
+		suffix string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "delete -e <env> <release> --suffix <suffix>",
+		Short: "Delete a preview copy of a release",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cat := catalog.FromContext(cmd.Context())
+			cat.WithEnvironments([]string{env})
+
+			return preview.Delete(preview.DeleteParams{
+				Catalog: cat,
+				Env:     env,
+				Release: args[0],
+				Suffix:  suffix,
+			})
+		},
+	}
+
+	cmd.Flags().StringVarP(&env, "env", "e", "", "Environment of the release")
+	cmd.Flags().StringVar(&suffix, "suffix", "", "Suffix identifying the preview (include the leading dash, e.g. -og-1234)")
+	_ = cmd.MarkFlagRequired("env")
+	_ = cmd.MarkFlagRequired("suffix")
+
+	return cmd
+}
+
+func parsePatchFlags(specs []string) ([]patch.Op, error) {
+	ops := make([]patch.Op, 0, len(specs))
+	for _, spec := range specs {
+		op, err := patch.ParseOp([]byte(spec))
+		if err != nil {
+			return nil, fmt.Errorf("parsing --patch %q: %w", spec, err)
+		}
+		ops = append(ops, op)
+	}
+	return ops, nil
+}
+
+func parseReplaceFlags(specs []string) ([]preview.Replacement, error) {
+	replacements := make([]preview.Replacement, 0, len(specs))
+	for _, spec := range specs {
+		var r preview.Replacement
+		if err := yaml.Unmarshal([]byte(spec), &r); err != nil {
+			return nil, fmt.Errorf("parsing --replace %q: %w", spec, err)
+		}
+		if r.Search == "" {
+			return nil, fmt.Errorf("invalid --replace %q: search is empty", spec)
+		}
+		replacements = append(replacements, r)
+	}
+	return replacements, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/davidmdm/x/xerr v0.0.6
 	github.com/davidmdm/x/xfs v0.0.5
+	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/go-test/deep v1.1.1
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/emicklei/proto v1.14.2 h1:wJPxPy2Xifja9cEMrcA/g08art5+7CGJNFNk35iXC1I
 github.com/emicklei/proto v1.14.2/go.mod h1:rn1FgRS/FANiZdD2djyH7TMA9jdRDcYQ9IEN9yvjX0A=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
+github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
+github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=

--- a/internal/build/promote.go
+++ b/internal/build/promote.go
@@ -33,7 +33,9 @@ func Promote(opts Opts) error {
 		}
 	}
 
-	excludeSelectors, err := labels.ParseSelectors(opts.ExcludeLabels)
+	// Always exclude preview releases (in addition to any caller-supplied selectors), so that
+	// promoting a project's real releases never overwrites the version of a preview copy.
+	excludeSelectors, err := labels.ParseSelectors(append([]string{v1alpha1.PreviewLabel}, opts.ExcludeLabels...))
 	if err != nil {
 		return fmt.Errorf("parsing exclude labels: %w", err)
 	}

--- a/internal/build/promote_test.go
+++ b/internal/build/promote_test.go
@@ -141,6 +141,40 @@ func TestPromoteExcludesLabeledReleases(t *testing.T) {
 	require.Equal(t, "1.1.2", yml.FindNodeValueOrDefault(writer.WriteFileCalls()[0].File.Tree, "spec.version", ""))
 }
 
+func TestPromoteAutoExcludesPreviewReleases(t *testing.T) {
+	var writer yml.WriterMock
+
+	environments := []*v1alpha1.Environment{{EnvironmentMetadata: v1alpha1.EnvironmentMetadata{ObjectMeta: metav1.ObjectMeta{Name: "staging"}}}}
+	release := func(name string, labels map[string]string) *cross.Release {
+		return &cross.Release{Releases: []*v1alpha1.Release{{
+			ReleaseMetadata: v1alpha1.ReleaseMetadata{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels}},
+			Spec:            v1alpha1.ReleaseSpec{Project: "promote-build"},
+			File:            makeFile(t, "{ spec: { version: 0.0.0 } }"),
+		}}}
+	}
+	opts := Opts{
+		Catalog: &catalog.Catalog{
+			Environments: environments,
+			Releases: cross.ReleaseList{
+				Environments: environments,
+				Items: []*cross.Release{
+					release("regular", nil),
+					release("preview", map[string]string{v1alpha1.PreviewLabel: "true"}),
+				},
+			},
+		},
+		Environment: "staging",
+		Writer:      &writer,
+		Project:     "promote-build",
+		Version:     "1.1.2",
+		// No ExcludeLabels: the preview label is excluded automatically.
+	}
+
+	require.NoError(t, Promote(opts))
+	require.Len(t, writer.WriteFileCalls(), 1)
+	require.Equal(t, "1.1.2", yml.FindNodeValueOrDefault(writer.WriteFileCalls()[0].File.Tree, "spec.version", ""))
+}
+
 func makeFile(t *testing.T, content string) *yml.File {
 	t.Helper()
 	f, err := yml.NewFile("", []byte(content))

--- a/internal/patch/patch.go
+++ b/internal/patch/patch.go
@@ -1,103 +1,109 @@
-// Package patch applies a subset of RFC 6902 JSON Patch (add / replace / remove) directly
-// against a gopkg.in/yaml.v3 node tree. Operating on nodes (rather than a JSON round-trip)
-// preserves the catalog's custom YAML tags (e.g. !lock) and node styles.
+// Package patch applies RFC 6902 JSON Patch operations to a YAML release tree.
+//
+// The patch itself is applied by a standard JSON Patch library, so serialization to JSON is
+// required — which drops YAML custom tags (e.g. !lock), comments and key order. Those are
+// restored from the original tree afterwards via yml.CopyMetadata. It also exposes a few
+// node-level setters used for built-in transforms that must run before the JSON round-trip.
 package patch
 
 import (
+	"bytes"
 	"fmt"
-	"slices"
-	"strconv"
-	"strings"
 
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	"gopkg.in/yaml.v3"
+	sigsyaml "sigs.k8s.io/yaml"
+
+	"github.com/nestoca/joy/internal/yml"
 )
 
-// Op is a single RFC 6902 operation.
+// Op is a single RFC 6902 operation, stored as its JSON encoding.
 type Op struct {
-	Op    string    `yaml:"op" json:"op"`
-	Path  string    `yaml:"path" json:"path"`
-	Value yaml.Node `yaml:"value" json:"value"`
+	json []byte
 }
 
-// ParseOp decodes a single RFC 6902 op (YAML or JSON object).
+// ParseOp decodes a single RFC 6902 op (YAML or JSON object) into its JSON form.
 func ParseOp(data []byte) (Op, error) {
-	var op Op
-	if strings.TrimSpace(string(data)) == "" {
-		return op, fmt.Errorf("empty patch op")
+	j, err := sigsyaml.YAMLToJSON(data)
+	if err != nil {
+		return Op{}, fmt.Errorf("decoding patch op: %w", err)
 	}
-	if err := yaml.Unmarshal(data, &op); err != nil {
-		return op, fmt.Errorf("decoding patch op: %w", err)
+	if trimmed := bytes.TrimSpace(j); len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return Op{}, fmt.Errorf("empty patch op")
 	}
-	// Normalize style so JSON-authored values (e.g. flow maps, double-quoted scalars) render as
-	// clean block YAML in the catalog. The encoder still re-quotes any scalar that needs it.
-	clearStyle(&op.Value)
-	return op, nil
+	return Op{json: j}, nil
 }
 
-func clearStyle(node *yaml.Node) {
-	if node == nil {
-		return
+// Apply applies the ops to doc (a document node) and returns the resulting document. The patch is
+// applied via a JSON Patch library; custom tags, comments and key order are then restored from
+// doc, and styles are cleared so the result serializes as clean block YAML. When there are no
+// ops, doc is returned unchanged.
+func Apply(doc *yaml.Node, ops []Op) (*yaml.Node, error) {
+	if len(ops) == 0 {
+		return doc, nil
 	}
-	node.Style = 0
-	for _, child := range node.Content {
-		clearStyle(child)
+
+	docJSON, err := toJSON(doc)
+	if err != nil {
+		return nil, fmt.Errorf("converting release to json: %w", err)
 	}
+
+	patch, err := jsonpatch.DecodePatch(patchArray(ops))
+	if err != nil {
+		return nil, fmt.Errorf("decoding patch: %w", err)
+	}
+
+	patchedJSON, err := patch.Apply(docJSON)
+	if err != nil {
+		return nil, fmt.Errorf("applying patch: %w", err)
+	}
+
+	var patched yaml.Node
+	if err := yaml.Unmarshal(patchedJSON, &patched); err != nil {
+		return nil, fmt.Errorf("parsing patched result: %w", err)
+	}
+
+	// The JSON round-trip drops custom tags, comments and key order, and flow-flattens styles.
+	yml.CopyMetadata(&patched, doc)
+	clearStyle(&patched)
+	return &patched, nil
 }
 
-// Apply runs each op against root (the mapping node, e.g. the document's first content node).
-func Apply(root *yaml.Node, ops []Op) error {
+// patchArray concatenates the ops' JSON objects into a single JSON Patch array.
+func patchArray(ops []Op) []byte {
+	parts := make([][]byte, len(ops))
 	for i, op := range ops {
-		if err := applyOp(root, op); err != nil {
-			return fmt.Errorf("patch op %d (%s %s): %w", i, op.Op, op.Path, err)
-		}
+		parts[i] = op.json
 	}
-	return nil
+	return append(append([]byte{'['}, bytes.Join(parts, []byte{','})...), ']')
 }
 
-func applyOp(root *yaml.Node, op Op) error {
-	tokens, err := parsePointer(op.Path)
+func toJSON(node *yaml.Node) ([]byte, error) {
+	data, err := yaml.Marshal(node)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	if len(tokens) == 0 {
-		return fmt.Errorf("cannot target the document root")
-	}
-	parent, last, err := resolveParent(root, tokens)
-	if err != nil {
-		if op.Op == "add" {
-			return fmt.Errorf("%w (RFC 6902 'add' requires the parent to exist; add the parent object instead)", err)
-		}
-		return err
-	}
-	switch op.Op {
-	case "add":
-		return addChild(parent, last, &op.Value)
-	case "replace":
-		return replaceChild(parent, last, &op.Value)
-	case "remove":
-		return removeChild(parent, last, false)
-	case "move", "copy", "test":
-		return fmt.Errorf("op %q is not supported (only add/replace/remove)", op.Op)
-	default:
-		return fmt.Errorf("unknown op %q", op.Op)
-	}
+	return sigsyaml.YAMLToJSON(data)
 }
 
-// SetPath sets tokens (a decomposed path) to val, adding or replacing as needed.
+// Scalar builds a plain string scalar node.
+func Scalar(value string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value}
+}
+
+// SetPath sets a mapping value at the given path (tokens), adding or replacing as needed. Every
+// intermediate node must already exist and be a mapping. Used for built-in transforms.
 func SetPath(root *yaml.Node, tokens []string, val *yaml.Node) error {
 	parent, last, err := resolveParent(root, tokens)
 	if err != nil {
 		return err
 	}
-	if parent.Kind != yaml.MappingNode {
-		return fmt.Errorf("SetPath %v: parent is not a mapping", tokens)
-	}
-	return setMapping(parent, last, val, false)
+	return setMapping(parent, last, val)
 }
 
-// SetPathCreating sets tokens to val, creating any missing intermediate mapping nodes along
-// the way (merging into existing ones rather than clobbering). Used for built-in transforms
-// that may target not-yet-existing parents (e.g. metadata.labels).
+// SetPathCreating is like SetPath but creates any missing intermediate mapping nodes (merging
+// into existing ones rather than clobbering). Used for built-ins that may target absent parents
+// (e.g. metadata.labels).
 func SetPathCreating(root *yaml.Node, tokens []string, val *yaml.Node) error {
 	cur := root
 	for _, t := range tokens[:len(tokens)-1] {
@@ -115,92 +121,36 @@ func SetPathCreating(root *yaml.Node, tokens []string, val *yaml.Node) error {
 	if cur.Kind != yaml.MappingNode {
 		return fmt.Errorf("SetPathCreating %v: parent is not a mapping", tokens)
 	}
-	return setMapping(cur, tokens[len(tokens)-1], val, false)
+	return setMapping(cur, tokens[len(tokens)-1], val)
 }
 
-// Scalar builds a plain string scalar node.
-func Scalar(value string) *yaml.Node {
-	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value}
+func resolveParent(root *yaml.Node, tokens []string) (*yaml.Node, string, error) {
+	if len(tokens) == 0 {
+		return nil, "", fmt.Errorf("empty path")
+	}
+	cur := root
+	for _, t := range tokens[:len(tokens)-1] {
+		if cur.Kind != yaml.MappingNode {
+			return nil, "", fmt.Errorf("path segment %q: parent is not a mapping", t)
+		}
+		i, ok := mappingIndex(cur, t)
+		if !ok {
+			return nil, "", fmt.Errorf("path segment %q not found", t)
+		}
+		cur = cur.Content[i+1]
+	}
+	return cur, tokens[len(tokens)-1], nil
 }
 
-func addChild(parent *yaml.Node, key string, val *yaml.Node) error {
-	if val == nil || val.Kind == 0 {
-		return fmt.Errorf("add: missing value")
+// setMapping adds or replaces key in a mapping node. When both old and new values are scalars,
+// the old node's tag/style/comments are preserved (so replacing a !lock value keeps !lock).
+func setMapping(m *yaml.Node, key string, val *yaml.Node) error {
+	if m.Kind != yaml.MappingNode {
+		return fmt.Errorf("cannot set key %q: parent is not a mapping", key)
 	}
-	switch parent.Kind {
-	case yaml.MappingNode:
-		return setMapping(parent, key, val, false)
-	case yaml.SequenceNode:
-		if key == "-" {
-			parent.Content = append(parent.Content, val)
-			return nil
-		}
-		idx, err := strconv.Atoi(key)
-		if err != nil || idx < 0 || idx > len(parent.Content) {
-			return fmt.Errorf("add: invalid array index %q", key)
-		}
-		parent.Content = slices.Insert(parent.Content, idx, val)
-		return nil
-	default:
-		return fmt.Errorf("add: parent is not a container")
-	}
-}
-
-func replaceChild(parent *yaml.Node, key string, val *yaml.Node) error {
-	if val == nil || val.Kind == 0 {
-		return fmt.Errorf("replace: missing value")
-	}
-	switch parent.Kind {
-	case yaml.MappingNode:
-		return setMapping(parent, key, val, true)
-	case yaml.SequenceNode:
-		idx, err := strconv.Atoi(key)
-		if err != nil || idx < 0 || idx >= len(parent.Content) {
-			return fmt.Errorf("replace: array index %q out of range", key)
-		}
-		parent.Content[idx] = preserveScalar(parent.Content[idx], val)
-		return nil
-	default:
-		return fmt.Errorf("replace: parent is not a container")
-	}
-}
-
-func removeChild(parent *yaml.Node, key string, tolerant bool) error {
-	switch parent.Kind {
-	case yaml.MappingNode:
-		if i, ok := mappingIndex(parent, key); ok {
-			parent.Content = append(parent.Content[:i], parent.Content[i+2:]...)
-			return nil
-		}
-		if tolerant {
-			return nil
-		}
-		return fmt.Errorf("remove: key %q not found", key)
-	case yaml.SequenceNode:
-		idx, err := strconv.Atoi(key)
-		if err != nil || idx < 0 || idx >= len(parent.Content) {
-			if tolerant {
-				return nil
-			}
-			return fmt.Errorf("remove: array index %q out of range", key)
-		}
-		parent.Content = slices.Delete(parent.Content, idx, idx+1)
-		return nil
-	default:
-		return fmt.Errorf("remove: parent is not a container")
-	}
-}
-
-// setMapping adds or replaces key in a mapping node. When the key exists and both the old and
-// new values are scalars, the old node's tag/style/comments are preserved (so replacing a
-// !lock value keeps !lock).
-func setMapping(m *yaml.Node, key string, val *yaml.Node, mustExist bool) error {
 	if i, ok := mappingIndex(m, key); ok {
 		m.Content[i+1] = preserveScalar(m.Content[i+1], val)
 		return nil
-	}
-	if mustExist {
-		return fmt.Errorf("key %q not found", key)
 	}
 	m.Content = append(m.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}, val)
 	return nil
@@ -226,50 +176,12 @@ func mappingIndex(m *yaml.Node, key string) (int, bool) {
 	return -1, false
 }
 
-// resolveParent walks all but the last token and returns the container + last token.
-func resolveParent(root *yaml.Node, tokens []string) (*yaml.Node, string, error) {
-	cur := root
-	for _, t := range tokens[:len(tokens)-1] {
-		next, err := child(cur, t)
-		if err != nil {
-			return nil, "", err
-		}
-		cur = next
+func clearStyle(node *yaml.Node) {
+	if node == nil {
+		return
 	}
-	return cur, tokens[len(tokens)-1], nil
-}
-
-func child(n *yaml.Node, token string) (*yaml.Node, error) {
-	switch n.Kind {
-	case yaml.MappingNode:
-		if i, ok := mappingIndex(n, token); ok {
-			return n.Content[i+1], nil
-		}
-		return nil, fmt.Errorf("key %q not found", token)
-	case yaml.SequenceNode:
-		idx, err := strconv.Atoi(token)
-		if err != nil || idx < 0 || idx >= len(n.Content) {
-			return nil, fmt.Errorf("array index %q out of range", token)
-		}
-		return n.Content[idx], nil
-	default:
-		return nil, fmt.Errorf("cannot descend into %q", token)
+	node.Style = 0
+	for _, child := range node.Content {
+		clearStyle(child)
 	}
-}
-
-// parsePointer splits an RFC 6901 JSON Pointer into unescaped tokens.
-func parsePointer(path string) ([]string, error) {
-	if path == "" {
-		return nil, nil
-	}
-	if !strings.HasPrefix(path, "/") {
-		return nil, fmt.Errorf("invalid JSON pointer %q: must start with '/'", path)
-	}
-	parts := strings.Split(path, "/")[1:]
-	for i, p := range parts {
-		p = strings.ReplaceAll(p, "~1", "/")
-		p = strings.ReplaceAll(p, "~0", "~")
-		parts[i] = p
-	}
-	return parts, nil
 }

--- a/internal/patch/patch.go
+++ b/internal/patch/patch.go
@@ -1,0 +1,275 @@
+// Package patch applies a subset of RFC 6902 JSON Patch (add / replace / remove) directly
+// against a gopkg.in/yaml.v3 node tree. Operating on nodes (rather than a JSON round-trip)
+// preserves the catalog's custom YAML tags (e.g. !lock) and node styles.
+package patch
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Op is a single RFC 6902 operation.
+type Op struct {
+	Op    string    `yaml:"op" json:"op"`
+	Path  string    `yaml:"path" json:"path"`
+	Value yaml.Node `yaml:"value" json:"value"`
+}
+
+// ParseOp decodes a single RFC 6902 op (YAML or JSON object).
+func ParseOp(data []byte) (Op, error) {
+	var op Op
+	if strings.TrimSpace(string(data)) == "" {
+		return op, fmt.Errorf("empty patch op")
+	}
+	if err := yaml.Unmarshal(data, &op); err != nil {
+		return op, fmt.Errorf("decoding patch op: %w", err)
+	}
+	// Normalize style so JSON-authored values (e.g. flow maps, double-quoted scalars) render as
+	// clean block YAML in the catalog. The encoder still re-quotes any scalar that needs it.
+	clearStyle(&op.Value)
+	return op, nil
+}
+
+func clearStyle(node *yaml.Node) {
+	if node == nil {
+		return
+	}
+	node.Style = 0
+	for _, child := range node.Content {
+		clearStyle(child)
+	}
+}
+
+// Apply runs each op against root (the mapping node, e.g. the document's first content node).
+func Apply(root *yaml.Node, ops []Op) error {
+	for i, op := range ops {
+		if err := applyOp(root, op); err != nil {
+			return fmt.Errorf("patch op %d (%s %s): %w", i, op.Op, op.Path, err)
+		}
+	}
+	return nil
+}
+
+func applyOp(root *yaml.Node, op Op) error {
+	tokens, err := parsePointer(op.Path)
+	if err != nil {
+		return err
+	}
+	if len(tokens) == 0 {
+		return fmt.Errorf("cannot target the document root")
+	}
+	parent, last, err := resolveParent(root, tokens)
+	if err != nil {
+		if op.Op == "add" {
+			return fmt.Errorf("%w (RFC 6902 'add' requires the parent to exist; add the parent object instead)", err)
+		}
+		return err
+	}
+	switch op.Op {
+	case "add":
+		return addChild(parent, last, &op.Value)
+	case "replace":
+		return replaceChild(parent, last, &op.Value)
+	case "remove":
+		return removeChild(parent, last, false)
+	case "move", "copy", "test":
+		return fmt.Errorf("op %q is not supported (only add/replace/remove)", op.Op)
+	default:
+		return fmt.Errorf("unknown op %q", op.Op)
+	}
+}
+
+// SetPath sets tokens (a decomposed path) to val, adding or replacing as needed.
+func SetPath(root *yaml.Node, tokens []string, val *yaml.Node) error {
+	parent, last, err := resolveParent(root, tokens)
+	if err != nil {
+		return err
+	}
+	if parent.Kind != yaml.MappingNode {
+		return fmt.Errorf("SetPath %v: parent is not a mapping", tokens)
+	}
+	return setMapping(parent, last, val, false)
+}
+
+// SetPathCreating sets tokens to val, creating any missing intermediate mapping nodes along
+// the way (merging into existing ones rather than clobbering). Used for built-in transforms
+// that may target not-yet-existing parents (e.g. metadata.labels).
+func SetPathCreating(root *yaml.Node, tokens []string, val *yaml.Node) error {
+	cur := root
+	for _, t := range tokens[:len(tokens)-1] {
+		if cur.Kind != yaml.MappingNode {
+			return fmt.Errorf("SetPathCreating %v: %q is not a mapping", tokens, t)
+		}
+		if i, ok := mappingIndex(cur, t); ok {
+			cur = cur.Content[i+1]
+			continue
+		}
+		child := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+		cur.Content = append(cur.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: t}, child)
+		cur = child
+	}
+	if cur.Kind != yaml.MappingNode {
+		return fmt.Errorf("SetPathCreating %v: parent is not a mapping", tokens)
+	}
+	return setMapping(cur, tokens[len(tokens)-1], val, false)
+}
+
+// Scalar builds a plain string scalar node.
+func Scalar(value string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value}
+}
+
+func addChild(parent *yaml.Node, key string, val *yaml.Node) error {
+	if val == nil || val.Kind == 0 {
+		return fmt.Errorf("add: missing value")
+	}
+	switch parent.Kind {
+	case yaml.MappingNode:
+		return setMapping(parent, key, val, false)
+	case yaml.SequenceNode:
+		if key == "-" {
+			parent.Content = append(parent.Content, val)
+			return nil
+		}
+		idx, err := strconv.Atoi(key)
+		if err != nil || idx < 0 || idx > len(parent.Content) {
+			return fmt.Errorf("add: invalid array index %q", key)
+		}
+		parent.Content = slices.Insert(parent.Content, idx, val)
+		return nil
+	default:
+		return fmt.Errorf("add: parent is not a container")
+	}
+}
+
+func replaceChild(parent *yaml.Node, key string, val *yaml.Node) error {
+	if val == nil || val.Kind == 0 {
+		return fmt.Errorf("replace: missing value")
+	}
+	switch parent.Kind {
+	case yaml.MappingNode:
+		return setMapping(parent, key, val, true)
+	case yaml.SequenceNode:
+		idx, err := strconv.Atoi(key)
+		if err != nil || idx < 0 || idx >= len(parent.Content) {
+			return fmt.Errorf("replace: array index %q out of range", key)
+		}
+		parent.Content[idx] = preserveScalar(parent.Content[idx], val)
+		return nil
+	default:
+		return fmt.Errorf("replace: parent is not a container")
+	}
+}
+
+func removeChild(parent *yaml.Node, key string, tolerant bool) error {
+	switch parent.Kind {
+	case yaml.MappingNode:
+		if i, ok := mappingIndex(parent, key); ok {
+			parent.Content = append(parent.Content[:i], parent.Content[i+2:]...)
+			return nil
+		}
+		if tolerant {
+			return nil
+		}
+		return fmt.Errorf("remove: key %q not found", key)
+	case yaml.SequenceNode:
+		idx, err := strconv.Atoi(key)
+		if err != nil || idx < 0 || idx >= len(parent.Content) {
+			if tolerant {
+				return nil
+			}
+			return fmt.Errorf("remove: array index %q out of range", key)
+		}
+		parent.Content = slices.Delete(parent.Content, idx, idx+1)
+		return nil
+	default:
+		return fmt.Errorf("remove: parent is not a container")
+	}
+}
+
+// setMapping adds or replaces key in a mapping node. When the key exists and both the old and
+// new values are scalars, the old node's tag/style/comments are preserved (so replacing a
+// !lock value keeps !lock).
+func setMapping(m *yaml.Node, key string, val *yaml.Node, mustExist bool) error {
+	if i, ok := mappingIndex(m, key); ok {
+		m.Content[i+1] = preserveScalar(m.Content[i+1], val)
+		return nil
+	}
+	if mustExist {
+		return fmt.Errorf("key %q not found", key)
+	}
+	m.Content = append(m.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}, val)
+	return nil
+}
+
+func preserveScalar(old, val *yaml.Node) *yaml.Node {
+	if old != nil && old.Kind == yaml.ScalarNode && val.Kind == yaml.ScalarNode {
+		c := *val
+		c.Tag = old.Tag
+		c.Style = old.Style
+		c.HeadComment, c.LineComment, c.FootComment = old.HeadComment, old.LineComment, old.FootComment
+		return &c
+	}
+	return val
+}
+
+func mappingIndex(m *yaml.Node, key string) (int, bool) {
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+// resolveParent walks all but the last token and returns the container + last token.
+func resolveParent(root *yaml.Node, tokens []string) (*yaml.Node, string, error) {
+	cur := root
+	for _, t := range tokens[:len(tokens)-1] {
+		next, err := child(cur, t)
+		if err != nil {
+			return nil, "", err
+		}
+		cur = next
+	}
+	return cur, tokens[len(tokens)-1], nil
+}
+
+func child(n *yaml.Node, token string) (*yaml.Node, error) {
+	switch n.Kind {
+	case yaml.MappingNode:
+		if i, ok := mappingIndex(n, token); ok {
+			return n.Content[i+1], nil
+		}
+		return nil, fmt.Errorf("key %q not found", token)
+	case yaml.SequenceNode:
+		idx, err := strconv.Atoi(token)
+		if err != nil || idx < 0 || idx >= len(n.Content) {
+			return nil, fmt.Errorf("array index %q out of range", token)
+		}
+		return n.Content[idx], nil
+	default:
+		return nil, fmt.Errorf("cannot descend into %q", token)
+	}
+}
+
+// parsePointer splits an RFC 6901 JSON Pointer into unescaped tokens.
+func parsePointer(path string) ([]string, error) {
+	if path == "" {
+		return nil, nil
+	}
+	if !strings.HasPrefix(path, "/") {
+		return nil, fmt.Errorf("invalid JSON pointer %q: must start with '/'", path)
+	}
+	parts := strings.Split(path, "/")[1:]
+	for i, p := range parts {
+		p = strings.ReplaceAll(p, "~1", "/")
+		p = strings.ReplaceAll(p, "~0", "~")
+		parts[i] = p
+	}
+	return parts, nil
+}

--- a/internal/patch/patch.go
+++ b/internal/patch/patch.go
@@ -7,7 +7,7 @@
 package patch
 
 import (
-	"bytes"
+	"encoding/json"
 	"fmt"
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
@@ -17,21 +17,25 @@ import (
 	"github.com/nestoca/joy/internal/yml"
 )
 
-// Op is a single RFC 6902 operation, stored as its JSON encoding.
+// Op is a single RFC 6902 operation. Value is an arbitrary JSON value (set for add/replace);
+// From is only set for move/copy.
 type Op struct {
-	json []byte
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	From  string `json:"from,omitempty"`
+	Value any    `json:"value,omitempty"`
 }
 
-// ParseOp decodes a single RFC 6902 op (YAML or JSON object) into its JSON form.
+// ParseOp decodes a single RFC 6902 op from YAML or JSON.
 func ParseOp(data []byte) (Op, error) {
-	j, err := sigsyaml.YAMLToJSON(data)
-	if err != nil {
-		return Op{}, fmt.Errorf("decoding patch op: %w", err)
+	var op Op
+	if err := sigsyaml.Unmarshal(data, &op); err != nil {
+		return Op{}, fmt.Errorf("parsing patch op: %w", err)
 	}
-	if trimmed := bytes.TrimSpace(j); len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
-		return Op{}, fmt.Errorf("empty patch op")
+	if op.Op == "" || op.Path == "" {
+		return Op{}, fmt.Errorf(`patch op must have both an "op" and a "path"`)
 	}
-	return Op{json: j}, nil
+	return op, nil
 }
 
 // Apply applies the ops to doc (a document node) and returns the resulting document. The patch is
@@ -48,7 +52,12 @@ func Apply(doc *yaml.Node, ops []Op) (*yaml.Node, error) {
 		return nil, fmt.Errorf("converting release to json: %w", err)
 	}
 
-	patch, err := jsonpatch.DecodePatch(patchArray(ops))
+	patchJSON, err := json.Marshal(ops)
+	if err != nil {
+		return nil, fmt.Errorf("encoding patch: %w", err)
+	}
+
+	patch, err := jsonpatch.DecodePatch(patchJSON)
 	if err != nil {
 		return nil, fmt.Errorf("decoding patch: %w", err)
 	}
@@ -67,15 +76,6 @@ func Apply(doc *yaml.Node, ops []Op) (*yaml.Node, error) {
 	yml.CopyMetadata(&patched, doc)
 	clearStyle(&patched)
 	return &patched, nil
-}
-
-// patchArray concatenates the ops' JSON objects into a single JSON Patch array.
-func patchArray(ops []Op) []byte {
-	parts := make([][]byte, len(ops))
-	for i, op := range ops {
-		parts[i] = op.json
-	}
-	return append(append([]byte{'['}, bytes.Join(parts, []byte{','})...), ']')
 }
 
 func toJSON(node *yaml.Node) ([]byte, error) {

--- a/internal/patch/patch_test.go
+++ b/internal/patch/patch_test.go
@@ -1,0 +1,110 @@
+package patch
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+const base = `
+spec:
+  namespace: default
+  values:
+    env:
+      ENV: !lock staging
+      PUBLIC_API_PATH: !lock https://office.staging.nesto.ca/api
+    frontend:
+      gateway:
+        httpRoutes: {}
+`
+
+func root(t *testing.T, src string) (*yaml.Node, *yaml.Node) {
+	t.Helper()
+	var doc yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(src), &doc))
+	return &doc, doc.Content[0]
+}
+
+func dump(t *testing.T, doc *yaml.Node) string {
+	t.Helper()
+	var b bytes.Buffer
+	enc := yaml.NewEncoder(&b)
+	enc.SetIndent(2)
+	require.NoError(t, enc.Encode(doc))
+	require.NoError(t, enc.Close())
+	return b.String()
+}
+
+func mustOp(t *testing.T, spec string) Op {
+	t.Helper()
+	op, err := ParseOp([]byte(spec))
+	require.NoError(t, err)
+	return op
+}
+
+func TestApply_AddReplaceRemove(t *testing.T) {
+	doc, r := root(t, base)
+	ops := []Op{
+		mustOp(t, `{op: add, path: /spec/values/image, value: {name: backoffice}}`),
+		mustOp(t, `{op: replace, path: /spec/values/env/PUBLIC_API_PATH, value: https://backoffice-og-1234.previews.staging.nesto.ca/api}`),
+		mustOp(t, `{op: remove, path: /spec/values/frontend/gateway}`),
+	}
+	require.NoError(t, Apply(r, ops))
+
+	out := dump(t, doc)
+	require.Contains(t, out, "name: backoffice")
+	require.Contains(t, out, "PUBLIC_API_PATH: !lock https://backoffice-og-1234.previews.staging.nesto.ca/api",
+		"replace must preserve the !lock tag")
+	require.Contains(t, out, "ENV: !lock staging")
+	require.NotContains(t, out, "gateway")
+}
+
+func TestApply_Errors(t *testing.T) {
+	_, r := root(t, base)
+	require.Error(t, Apply(r, []Op{mustOp(t, `{op: replace, path: /spec/values/env/NOPE, value: x}`)}))
+	_, r = root(t, base)
+	require.Error(t, Apply(r, []Op{mustOp(t, `{op: remove, path: /spec/values/nope}`)}))
+	_, r = root(t, base)
+	err := Apply(r, []Op{mustOp(t, `{op: add, path: /spec/values/image/name, value: x}`)})
+	require.ErrorContains(t, err, "add the parent object instead")
+	for _, op := range []string{"move", "copy", "test"} {
+		_, r := root(t, base)
+		require.Error(t, Apply(r, []Op{mustOp(t, "{op: "+op+", path: /spec/namespace, value: x}")}))
+	}
+}
+
+func TestSetPathCreating(t *testing.T) {
+	doc, r := root(t, base)
+	require.NoError(t, SetPathCreating(r, []string{"metadata", "labels", "joy.nesto.ca/preview"}, Scalar("true")))
+	require.NoError(t, SetPathCreating(r, []string{"spec", "values", "env", "NEW"}, Scalar("v")))
+
+	out := dump(t, doc)
+	require.Contains(t, out, `joy.nesto.ca/preview: "true"`)
+	require.Contains(t, out, "NEW: v")
+	require.Contains(t, out, "ENV: !lock staging", "existing siblings must survive")
+}
+
+func TestParseOp_NormalizesStyleToBlock(t *testing.T) {
+	// JSON-authored values (flow map, double-quoted scalars) should render as clean block YAML.
+	doc, r := root(t, base)
+	op, err := ParseOp([]byte(`{"op":"add","path":"/spec/values/image","value":{"name":"backoffice"}}`))
+	require.NoError(t, err)
+	ns, err := ParseOp([]byte(`{"op":"add","path":"/spec/namespace","value":"previews"}`))
+	require.NoError(t, err)
+	require.NoError(t, Apply(r, []Op{op, ns}))
+
+	out := dump(t, doc)
+	require.Contains(t, out, "namespace: previews")  // not: namespace: "previews"
+	require.Contains(t, out, "    name: backoffice") // block, not: image: {"name": ...}
+	require.NotContains(t, out, `{"name"`)
+}
+
+func TestParsePointerEscapes(t *testing.T) {
+	got, err := parsePointer("/a~1b/c~0d")
+	require.NoError(t, err)
+	require.Equal(t, []string{"a/b", "c~d"}, got)
+	_, err = parsePointer("no-leading-slash")
+	require.Error(t, err)
+}

--- a/internal/patch/patch_test.go
+++ b/internal/patch/patch_test.go
@@ -2,109 +2,94 @@ package patch
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
 
-const base = `
-spec:
+const base = `spec:
   namespace: default
   values:
     env:
-      ENV: !lock staging
-      PUBLIC_API_PATH: !lock https://office.staging.nesto.ca/api
+      ZULU: !lock z
+      ALPHA: !lock a
     frontend:
       gateway:
         httpRoutes: {}
 `
 
-func root(t *testing.T, src string) (*yaml.Node, *yaml.Node) {
+func doc(t *testing.T, src string) *yaml.Node {
 	t.Helper()
-	var doc yaml.Node
-	require.NoError(t, yaml.Unmarshal([]byte(src), &doc))
-	return &doc, doc.Content[0]
+	var d yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(src), &d))
+	return &d
 }
 
-func dump(t *testing.T, doc *yaml.Node) string {
+func mustOp(t *testing.T, s string) Op {
 	t.Helper()
-	var b bytes.Buffer
-	enc := yaml.NewEncoder(&b)
-	enc.SetIndent(2)
-	require.NoError(t, enc.Encode(doc))
-	require.NoError(t, enc.Close())
-	return b.String()
-}
-
-func mustOp(t *testing.T, spec string) Op {
-	t.Helper()
-	op, err := ParseOp([]byte(spec))
+	op, err := ParseOp([]byte(s))
 	require.NoError(t, err)
 	return op
 }
 
-func TestApply_AddReplaceRemove(t *testing.T) {
-	doc, r := root(t, base)
-	ops := []Op{
+func render(t *testing.T, d *yaml.Node) string {
+	t.Helper()
+	var b bytes.Buffer
+	enc := yaml.NewEncoder(&b)
+	enc.SetIndent(2)
+	require.NoError(t, enc.Encode(d))
+	require.NoError(t, enc.Close())
+	return b.String()
+}
+
+func TestApply(t *testing.T) {
+	out, err := Apply(doc(t, base), []Op{
 		mustOp(t, `{op: add, path: /spec/values/image, value: {name: backoffice}}`),
-		mustOp(t, `{op: replace, path: /spec/values/env/PUBLIC_API_PATH, value: https://backoffice-og-1234.previews.staging.nesto.ca/api}`),
+		mustOp(t, `{op: replace, path: /spec/values/env/ALPHA, value: A2}`),
 		mustOp(t, `{op: remove, path: /spec/values/frontend/gateway}`),
-	}
-	require.NoError(t, Apply(r, ops))
-
-	out := dump(t, doc)
-	require.Contains(t, out, "name: backoffice")
-	require.Contains(t, out, "PUBLIC_API_PATH: !lock https://backoffice-og-1234.previews.staging.nesto.ca/api",
-		"replace must preserve the !lock tag")
-	require.Contains(t, out, "ENV: !lock staging")
-	require.NotContains(t, out, "gateway")
-}
-
-func TestApply_Errors(t *testing.T) {
-	_, r := root(t, base)
-	require.Error(t, Apply(r, []Op{mustOp(t, `{op: replace, path: /spec/values/env/NOPE, value: x}`)}))
-	_, r = root(t, base)
-	require.Error(t, Apply(r, []Op{mustOp(t, `{op: remove, path: /spec/values/nope}`)}))
-	_, r = root(t, base)
-	err := Apply(r, []Op{mustOp(t, `{op: add, path: /spec/values/image/name, value: x}`)})
-	require.ErrorContains(t, err, "add the parent object instead")
-	for _, op := range []string{"move", "copy", "test"} {
-		_, r := root(t, base)
-		require.Error(t, Apply(r, []Op{mustOp(t, "{op: "+op+", path: /spec/namespace, value: x}")}))
-	}
-}
-
-func TestSetPathCreating(t *testing.T) {
-	doc, r := root(t, base)
-	require.NoError(t, SetPathCreating(r, []string{"metadata", "labels", "joy.nesto.ca/preview"}, Scalar("true")))
-	require.NoError(t, SetPathCreating(r, []string{"spec", "values", "env", "NEW"}, Scalar("v")))
-
-	out := dump(t, doc)
-	require.Contains(t, out, `joy.nesto.ca/preview: "true"`)
-	require.Contains(t, out, "NEW: v")
-	require.Contains(t, out, "ENV: !lock staging", "existing siblings must survive")
-}
-
-func TestParseOp_NormalizesStyleToBlock(t *testing.T) {
-	// JSON-authored values (flow map, double-quoted scalars) should render as clean block YAML.
-	doc, r := root(t, base)
-	op, err := ParseOp([]byte(`{"op":"add","path":"/spec/values/image","value":{"name":"backoffice"}}`))
+	})
 	require.NoError(t, err)
-	ns, err := ParseOp([]byte(`{"op":"add","path":"/spec/namespace","value":"previews"}`))
-	require.NoError(t, err)
-	require.NoError(t, Apply(r, []Op{op, ns}))
+	s := render(t, out)
 
-	out := dump(t, doc)
-	require.Contains(t, out, "namespace: previews")  // not: namespace: "previews"
-	require.Contains(t, out, "    name: backoffice") // block, not: image: {"name": ...}
-	require.NotContains(t, out, `{"name"`)
+	// Custom tags restored by CopyMetadata (including on a replaced value).
+	require.Contains(t, s, "ZULU: !lock z")
+	require.Contains(t, s, "ALPHA: !lock A2")
+	// Source key order preserved (ZULU before ALPHA), not alphabetized.
+	require.Less(t, strings.Index(s, "ZULU"), strings.Index(s, "ALPHA"))
+	// De-flowed to block style (no leftover JSON braces from the round-trip).
+	require.NotContains(t, s, `{"`)
+	// Patch effects.
+	require.Contains(t, s, "name: backoffice")
+	require.NotContains(t, s, "httpRoutes")
 }
 
-func TestParsePointerEscapes(t *testing.T) {
-	got, err := parsePointer("/a~1b/c~0d")
+func TestApply_NoOpsReturnsInput(t *testing.T) {
+	in := doc(t, base)
+	out, err := Apply(in, nil)
 	require.NoError(t, err)
-	require.Equal(t, []string{"a/b", "c~d"}, got)
-	_, err = parsePointer("no-leading-slash")
+	require.Same(t, in, out)
+}
+
+func TestApply_StrictErrors(t *testing.T) {
+	// RFC 6902: replacing a non-existent path is an error.
+	_, err := Apply(doc(t, base), []Op{mustOp(t, `{op: replace, path: /spec/values/nope, value: x}`)})
 	require.Error(t, err)
+	// add to a non-existent parent is an error.
+	_, err = Apply(doc(t, base), []Op{mustOp(t, `{op: add, path: /spec/values/image/name, value: x}`)})
+	require.Error(t, err)
+}
+
+func TestSetPathAndSetPathCreating(t *testing.T) {
+	d := doc(t, base)
+	root := d.Content[0]
+	require.NoError(t, SetPath(root, []string{"spec", "namespace"}, Scalar("previews")))
+	require.NoError(t, SetPathCreating(root, []string{"metadata", "labels", "joy.nesto.ca/preview"}, Scalar("true")))
+
+	s := render(t, d)
+	require.Contains(t, s, "namespace: previews")
+	require.Contains(t, s, `joy.nesto.ca/preview: "true"`)
+	// Existing !lock values untouched by the setters.
+	require.Contains(t, s, "ZULU: !lock z")
 }

--- a/internal/preview/preview.go
+++ b/internal/preview/preview.go
@@ -87,12 +87,13 @@ func Create(params CreateParams) error {
 		return fmt.Errorf("setting spec.version: %w", err)
 	}
 
-	// Caller patches (RFC 6902), applied in order.
-	if err := patch.Apply(node, params.Patches); err != nil {
+	// Caller patches (RFC 6902), applied via the JSON Patch library (tags/comments/order restored).
+	patched, err := patch.Apply(tree, params.Patches)
+	if err != nil {
 		return err
 	}
 
-	targetFile, err := yml.NewFileFromTree(targetPath, source.File.Indent, tree)
+	targetFile, err := yml.NewFileFromTree(targetPath, source.File.Indent, patched)
 	if err != nil {
 		return fmt.Errorf("building preview file: %w", err)
 	}

--- a/internal/preview/preview.go
+++ b/internal/preview/preview.go
@@ -1,0 +1,197 @@
+// Package preview creates, updates and deletes preview copies of a release in the catalog.
+//
+// A preview is a copy of a source release named <sourceRelease><suffix>, pinned to a specific
+// build version and marked with the v1alpha1.PreviewLabel so that `joy build promote` excludes
+// it. Callers layer their own transforms via patches (RFC 6902) and regex replacements.
+package preview
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/nestoca/joy/api/v1alpha1"
+	"github.com/nestoca/joy/internal/patch"
+	"github.com/nestoca/joy/internal/style"
+	"github.com/nestoca/joy/internal/yml"
+	"github.com/nestoca/joy/pkg/catalog"
+)
+
+// Replacement is a single regex search/replace applied to the preview file text.
+type Replacement struct {
+	Search  string `yaml:"search" json:"search"`
+	Replace string `yaml:"replace" json:"replace"`
+}
+
+// CreateParams are the inputs to Create.
+type CreateParams struct {
+	Catalog  *catalog.Catalog
+	Writer   yml.Writer
+	Env      string
+	Release  string // source release name
+	Suffix   string // appended to Release to form the preview name; includes any leading dash
+	Version  string
+	Patches  []patch.Op
+	Replaces []Replacement
+}
+
+// DeleteParams are the inputs to Delete.
+type DeleteParams struct {
+	Catalog *catalog.Catalog
+	Env     string
+	Release string
+	Suffix  string
+}
+
+// Create writes (or, if it already exists, version-bumps) the preview copy of a release.
+//
+// New preview: copy source → built-ins (metadata.name, preview label, version) → patches →
+// replacements → placeholder substitution (__RELEASE__, __SUFFIX__). Existing preview: only
+// spec.version is re-patched (copy is idempotent; other transforms are not re-applied).
+func Create(params CreateParams) error {
+	source, err := findSourceRelease(params.Catalog, params.Release, params.Env)
+	if err != nil {
+		return err
+	}
+	if params.Suffix == "" {
+		return fmt.Errorf("suffix must not be empty")
+	}
+	if params.Version == "" {
+		return fmt.Errorf("version must not be empty")
+	}
+
+	target := params.Release + params.Suffix
+	targetPath := filepath.Join(filepath.Dir(source.File.Path), target+".yaml")
+
+	if _, err := os.Stat(targetPath); err == nil {
+		return updateVersion(params.Writer, targetPath, params.Version, target)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("checking preview file %s: %w", targetPath, err)
+	}
+
+	tree := yml.Clone(source.File.Tree)
+	node := documentRoot(tree)
+
+	// joy built-ins.
+	if err := patch.SetPath(node, []string{"metadata", "name"}, patch.Scalar(target)); err != nil {
+		return fmt.Errorf("setting metadata.name: %w", err)
+	}
+	if err := patch.SetPathCreating(node, []string{"metadata", "labels", v1alpha1.PreviewLabel}, patch.Scalar("true")); err != nil {
+		return fmt.Errorf("setting preview label: %w", err)
+	}
+	if err := patch.SetPath(node, []string{"spec", "version"}, patch.Scalar(params.Version)); err != nil {
+		return fmt.Errorf("setting spec.version: %w", err)
+	}
+
+	// Caller patches (RFC 6902), applied in order.
+	if err := patch.Apply(node, params.Patches); err != nil {
+		return err
+	}
+
+	targetFile, err := yml.NewFileFromTree(targetPath, source.File.Indent, tree)
+	if err != nil {
+		return fmt.Errorf("building preview file: %w", err)
+	}
+
+	// Text transforms: regex replacements, then the final placeholder pass.
+	text, err := applyReplacements(string(targetFile.Yaml), params.Replaces)
+	if err != nil {
+		return err
+	}
+	text = applyPlaceholders(text, params.Release, params.Suffix)
+	targetFile.Yaml = []byte(text)
+
+	if err := params.Writer.WriteFile(targetFile); err != nil {
+		return fmt.Errorf("writing preview file: %w", err)
+	}
+	fmt.Printf("✅ Created preview %s at version %s\n", style.Resource(target), style.Version(params.Version))
+	return nil
+}
+
+// Delete removes the preview copy of a release, if it exists.
+func Delete(params DeleteParams) error {
+	source, err := findSourceRelease(params.Catalog, params.Release, params.Env)
+	if err != nil {
+		return err
+	}
+	if params.Suffix == "" {
+		return fmt.Errorf("suffix must not be empty")
+	}
+
+	target := params.Release + params.Suffix
+	targetPath := filepath.Join(filepath.Dir(source.File.Path), target+".yaml")
+
+	if _, err := os.Stat(targetPath); err != nil {
+		if os.IsNotExist(err) {
+			fmt.Printf("ℹ️ Preview %s does not exist; nothing to delete\n", style.Resource(target))
+			return nil
+		}
+		return fmt.Errorf("checking preview file %s: %w", targetPath, err)
+	}
+	if err := os.Remove(targetPath); err != nil {
+		return fmt.Errorf("removing preview file %s: %w", targetPath, err)
+	}
+	fmt.Printf("🗑️  Deleted preview %s\n", style.Resource(target))
+	return nil
+}
+
+func updateVersion(writer yml.Writer, path, version, target string) error {
+	file, err := yml.LoadFile(path)
+	if err != nil {
+		return fmt.Errorf("loading preview file %s: %w", path, err)
+	}
+	if err := patch.SetPath(documentRoot(file.Tree), []string{"spec", "version"}, patch.Scalar(version)); err != nil {
+		return fmt.Errorf("setting spec.version: %w", err)
+	}
+	if err := file.UpdateYamlFromTree(); err != nil {
+		return fmt.Errorf("updating preview yaml: %w", err)
+	}
+	if err := writer.WriteFile(file); err != nil {
+		return fmt.Errorf("writing preview file: %w", err)
+	}
+	fmt.Printf("✅ Updated preview %s to version %s\n", style.Resource(target), style.Version(version))
+	return nil
+}
+
+// findSourceRelease locates the source release within the (single-environment) catalog.
+func findSourceRelease(cat *catalog.Catalog, name, env string) (*v1alpha1.Release, error) {
+	for _, crossRelease := range cat.Releases.Items {
+		if crossRelease.Name != name {
+			continue
+		}
+		if len(crossRelease.Releases) == 0 || crossRelease.Releases[0] == nil || crossRelease.Releases[0].File == nil {
+			return nil, fmt.Errorf("release %q not found in environment %q", name, env)
+		}
+		return crossRelease.Releases[0], nil
+	}
+	return nil, fmt.Errorf("release %q not found", name)
+}
+
+func applyReplacements(text string, replacements []Replacement) (string, error) {
+	for _, r := range replacements {
+		re, err := regexp.Compile(r.Search)
+		if err != nil {
+			return "", fmt.Errorf("invalid search regex %q: %w", r.Search, err)
+		}
+		text = re.ReplaceAllString(text, r.Replace)
+	}
+	return text, nil
+}
+
+func applyPlaceholders(text, release, suffix string) string {
+	return strings.NewReplacer(
+		"__RELEASE__", release,
+		"__SUFFIX__", suffix,
+	).Replace(text)
+}
+
+func documentRoot(tree *yaml.Node) *yaml.Node {
+	if tree.Kind == yaml.DocumentNode && len(tree.Content) > 0 {
+		return tree.Content[0]
+	}
+	return tree
+}

--- a/internal/preview/preview_test.go
+++ b/internal/preview/preview_test.go
@@ -1,0 +1,173 @@
+package preview
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/nestoca/joy/api/v1alpha1"
+	"github.com/nestoca/joy/internal/patch"
+	"github.com/nestoca/joy/internal/release/cross"
+	"github.com/nestoca/joy/internal/yml"
+	"github.com/nestoca/joy/pkg/catalog"
+)
+
+const sourceYAML = `apiVersion: joy.nesto.ca/v1alpha1
+kind: Release
+metadata:
+  name: backoffice
+spec:
+  project: backoffice
+  version: 0.2569.0
+  values:
+    frontend:
+      gateway:
+        httpRoutes:
+          main:
+            hostnames: !lock
+              - office.staging.nesto.ca
+    env:
+      ENV: !lock staging
+      PUBLIC_API_PATH: !lock https://office.staging.nesto.ca/api
+`
+
+func newCatalog(t *testing.T) (dir string, cat *catalog.Catalog) {
+	t.Helper()
+	dir = t.TempDir()
+	relDir := filepath.Join(dir, "environments", "staging", "releases", "origination")
+	require.NoError(t, os.MkdirAll(relDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(relDir, "backoffice.yaml"), []byte(sourceYAML), 0o644))
+
+	file, err := yml.LoadFile(filepath.Join(relDir, "backoffice.yaml"))
+	require.NoError(t, err)
+	rel, err := v1alpha1.LoadRelease(file)
+	require.NoError(t, err)
+
+	envs := []*v1alpha1.Environment{{EnvironmentMetadata: v1alpha1.EnvironmentMetadata{ObjectMeta: metav1.ObjectMeta{Name: "staging"}}}}
+	cat = &catalog.Catalog{
+		Environments: envs,
+		Releases: cross.ReleaseList{
+			Environments: envs,
+			Items:        []*cross.Release{{Name: "backoffice", Releases: []*v1alpha1.Release{rel}}},
+		},
+	}
+	return dir, cat
+}
+
+// nestoPatches mirrors the built-in transforms the preview-service action passes.
+func nestoPatches(t *testing.T) []patch.Op {
+	t.Helper()
+	specs := []string{
+		`{op: remove, path: /spec/values/frontend/gateway}`,
+		`{op: add, path: /spec/namespace, value: previews}`,
+		`{op: add, path: /spec/values/image, value: {name: backoffice}}`,
+	}
+	ops := make([]patch.Op, 0, len(specs))
+	for _, s := range specs {
+		op, err := patch.ParseOp([]byte(s))
+		require.NoError(t, err)
+		ops = append(ops, op)
+	}
+	return ops
+}
+
+func previewPath(dir string) string {
+	return filepath.Join(dir, "environments", "staging", "releases", "origination", "backoffice-og-1234.yaml")
+}
+
+func decode(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, yaml.Unmarshal(data, &m))
+	return m
+}
+
+func TestCreate(t *testing.T) {
+	dir, cat := newCatalog(t)
+	err := Create(CreateParams{
+		Catalog: cat, Writer: yml.DiskWriter,
+		Env: "staging", Release: "backoffice", Suffix: "-og-1234", Version: "1.2.3-preview",
+		Patches: nestoPatches(t),
+		Replaces: []Replacement{{
+			Search:  `(https://)(office)(\.staging\..*/api)`,
+			Replace: `${1}__RELEASE____SUFFIX__.previews$3`,
+		}},
+	})
+	require.NoError(t, err)
+
+	text, err := os.ReadFile(previewPath(dir))
+	require.NoError(t, err)
+	s := string(text)
+
+	require.Contains(t, s, "name: backoffice-og-1234")
+	require.Contains(t, s, "version: 1.2.3-preview")
+	require.NotContains(t, s, "gateway")
+	// placeholders resolved inside the regex replacement + !lock preserved:
+	require.Contains(t, s, "PUBLIC_API_PATH: !lock https://backoffice-og-1234.previews.staging.nesto.ca/api")
+	require.Contains(t, s, "ENV: !lock staging")
+
+	m := decode(t, previewPath(dir))
+	require.Equal(t, "true", m["metadata"].(map[string]any)["labels"].(map[string]any)[v1alpha1.PreviewLabel])
+	spec := m["spec"].(map[string]any)
+	require.Equal(t, "previews", spec["namespace"])
+	require.Equal(t, "backoffice", spec["values"].(map[string]any)["image"].(map[string]any)["name"])
+}
+
+func TestCreateUpdateOnlyBumpsVersion(t *testing.T) {
+	dir, cat := newCatalog(t)
+	require.NoError(t, Create(CreateParams{
+		Catalog: cat, Writer: yml.DiskWriter, Env: "staging",
+		Release: "backoffice", Suffix: "-og-1234", Version: "1.0.0", Patches: nestoPatches(t),
+	}))
+
+	// Second create with a different version + a patch that must NOT be re-applied.
+	extra, err := patch.ParseOp([]byte(`{op: add, path: /spec/values/SHOULD_NOT_APPEAR, value: x}`))
+	require.NoError(t, err)
+	require.NoError(t, Create(CreateParams{
+		Catalog: cat, Writer: yml.DiskWriter, Env: "staging",
+		Release: "backoffice", Suffix: "-og-1234", Version: "9.9.9", Patches: []patch.Op{extra},
+	}))
+
+	text, err := os.ReadFile(previewPath(dir))
+	require.NoError(t, err)
+	require.Contains(t, string(text), "version: 9.9.9")
+	require.NotContains(t, string(text), "SHOULD_NOT_APPEAR")
+}
+
+func TestDelete(t *testing.T) {
+	dir, cat := newCatalog(t)
+	require.NoError(t, Create(CreateParams{
+		Catalog: cat, Writer: yml.DiskWriter, Env: "staging",
+		Release: "backoffice", Suffix: "-og-1234", Version: "1.0.0",
+	}))
+	require.FileExists(t, previewPath(dir))
+
+	require.NoError(t, Delete(DeleteParams{Catalog: cat, Env: "staging", Release: "backoffice", Suffix: "-og-1234"}))
+	require.NoFileExists(t, previewPath(dir))
+
+	// Deleting again is a no-op.
+	require.NoError(t, Delete(DeleteParams{Catalog: cat, Env: "staging", Release: "backoffice", Suffix: "-og-1234"}))
+}
+
+func TestCreateErrors(t *testing.T) {
+	_, cat := newCatalog(t)
+	base := CreateParams{Catalog: cat, Writer: yml.DiskWriter, Env: "staging", Release: "backoffice", Suffix: "-og-1234", Version: "1.0.0"}
+
+	unknown := base
+	unknown.Release = "does-not-exist"
+	require.Error(t, Create(unknown))
+
+	noSuffix := base
+	noSuffix.Suffix = ""
+	require.Error(t, Create(noSuffix))
+
+	noVersion := base
+	noVersion.Version = ""
+	require.Error(t, Create(noVersion))
+}

--- a/internal/yml/copy_metadata.go
+++ b/internal/yml/copy_metadata.go
@@ -18,6 +18,10 @@ import (
 // It walks both trees in parallel, stopping on any branch where the nodes are nil or differ in
 // kind (i.e. structurally changed relative to src). It never moves data between branches: every
 // dst node is preserved.
+//
+// Sequence *elements* are not reconciled: a JSON Patch may add/remove/move items, so matching by
+// index is unreliable and would risk copying metadata onto the wrong element. The sequence node's
+// own tag/comments are still restored; per-element metadata inside sequences is a known limitation.
 func CopyMetadata(dst, src *yaml.Node) {
 	if dst == nil || src == nil || dst.Kind != src.Kind {
 		return
@@ -31,10 +35,16 @@ func CopyMetadata(dst, src *yaml.Node) {
 	dst.FootComment = src.FootComment
 
 	switch dst.Kind {
-	case yaml.DocumentNode, yaml.SequenceNode:
+	case yaml.DocumentNode:
+		// A document wraps a single root node, so index correspondence is safe.
 		for i := 0; i < min(len(dst.Content), len(src.Content)); i++ {
 			CopyMetadata(dst.Content[i], src.Content[i])
 		}
+	// NOTE: sequence *elements* are intentionally not recursed into. A JSON Patch add/remove/move
+	// shifts indices, so dst.Content[i] may no longer correspond to src.Content[i]; copying by
+	// index would attach tags/comments (e.g. !lock) to the wrong element. The sequence node's own
+	// tag and comments are still restored (copied above). Reconciling element metadata would need
+	// patch-aware correspondence — a known limitation for now.
 	case yaml.MappingNode:
 		dstByKey := asMap(dst)
 		reordered := make([]*yaml.Node, 0, len(dst.Content))

--- a/internal/yml/copy_metadata.go
+++ b/internal/yml/copy_metadata.go
@@ -1,0 +1,63 @@
+package yml
+
+import (
+	"slices"
+
+	"gopkg.in/yaml.v3"
+)
+
+// CopyMetadata reconciles dst to the authored form of src, restoring presentation that is lost
+// when a tree is rebuilt from JSON (e.g. after applying a JSON Patch). It copies, onto matching
+// nodes:
+//
+//   - custom YAML tags (those in CustomTags, e.g. !lock),
+//   - head/line/foot comments,
+//   - and, for mappings, src's key order (keys present only in dst — e.g. added by a patch — are
+//     kept and appended after the src-ordered ones).
+//
+// It walks both trees in parallel, stopping on any branch where the nodes are nil or differ in
+// kind (i.e. structurally changed relative to src). It never moves data between branches: every
+// dst node is preserved.
+func CopyMetadata(dst, src *yaml.Node) {
+	if dst == nil || src == nil || dst.Kind != src.Kind {
+		return
+	}
+
+	if slices.Contains(CustomTags, src.Tag) {
+		dst.Tag = src.Tag
+	}
+	dst.HeadComment = src.HeadComment
+	dst.LineComment = src.LineComment
+	dst.FootComment = src.FootComment
+
+	switch dst.Kind {
+	case yaml.DocumentNode, yaml.SequenceNode:
+		for i := 0; i < min(len(dst.Content), len(src.Content)); i++ {
+			CopyMetadata(dst.Content[i], src.Content[i])
+		}
+	case yaml.MappingNode:
+		dstByKey := asMap(dst)
+		reordered := make([]*yaml.Node, 0, len(dst.Content))
+		seen := make(map[string]bool, len(dst.Content)/2)
+
+		// dst pairs in src's key order, recursing into the matched ones.
+		for i := 0; i+1 < len(src.Content); i += 2 {
+			key := src.Content[i].Value
+			dstPair, ok := dstByKey[key]
+			if !ok {
+				continue
+			}
+			CopyMetadata(dstPair.Key, src.Content[i])
+			CopyMetadata(dstPair.Value, src.Content[i+1])
+			reordered = append(reordered, dstPair.Key, dstPair.Value)
+			seen[key] = true
+		}
+		// dst-only keys (e.g. added by a patch), in their current order.
+		for i := 0; i+1 < len(dst.Content); i += 2 {
+			if key := dst.Content[i].Value; !seen[key] {
+				reordered = append(reordered, dst.Content[i], dst.Content[i+1])
+			}
+		}
+		dst.Content = reordered
+	}
+}

--- a/internal/yml/copy_metadata_test.go
+++ b/internal/yml/copy_metadata_test.go
@@ -1,0 +1,59 @@
+package yml
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func nodeOf(t *testing.T, src string) *yaml.Node {
+	t.Helper()
+	var n yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(src), &n))
+	return &n
+}
+
+func renderNode(t *testing.T, n *yaml.Node) string {
+	t.Helper()
+	var b bytes.Buffer
+	enc := yaml.NewEncoder(&b)
+	enc.SetIndent(2)
+	require.NoError(t, enc.Encode(n))
+	require.NoError(t, enc.Close())
+	return b.String()
+}
+
+func TestCopyMetadata(t *testing.T) {
+	// src: authored form — custom tag, a comment, and a deliberate (non-alphabetical) key order.
+	src := nodeOf(t, `zebra: 1
+spec:
+  version: 9 # keep me
+  env:
+    LOCKED: !lock secret
+`)
+	// dst: same data but alphabetized, no tags/comments (as if rebuilt from JSON), plus a new key.
+	dst := nodeOf(t, `spec:
+  env:
+    LOCKED: secret
+    ADDED: new
+  version: 9
+zebra: 1
+`)
+
+	CopyMetadata(dst, src)
+	out := renderNode(t, dst)
+
+	// Custom tag restored.
+	require.Contains(t, out, "LOCKED: !lock secret")
+	// Comment restored.
+	require.Contains(t, out, "keep me")
+	// src key order restored (zebra before spec; version before env; LOCKED before the added key).
+	require.Less(t, strings.Index(out, "zebra"), strings.Index(out, "spec"))
+	require.Less(t, strings.Index(out, "version"), strings.Index(out, "env"))
+	require.Less(t, strings.Index(out, "LOCKED"), strings.Index(out, "ADDED"))
+	// dst-only key preserved (appended, not dropped).
+	require.Contains(t, out, "ADDED: new")
+}

--- a/internal/yml/copy_metadata_test.go
+++ b/internal/yml/copy_metadata_test.go
@@ -57,3 +57,25 @@ zebra: 1
 	// dst-only key preserved (appended, not dropped).
 	require.Contains(t, out, "ADDED: new")
 }
+
+func TestCopyMetadataDoesNotReconcileSequenceElements(t *testing.T) {
+	// src: a !lock-tagged sequence whose first element also carries a custom tag.
+	src := nodeOf(t, `list: !lock
+  - !lock aaa
+  - bbb
+`)
+	// dst: as if a patch removed/shifted elements (and the JSON round-trip dropped tags).
+	dst := nodeOf(t, `list:
+  - ccc
+`)
+
+	CopyMetadata(dst, src)
+
+	list := dst.Content[0].Content[1] // document -> root mapping -> value of "list"
+	// The sequence node's own tag is restored...
+	require.Equal(t, "!lock", list.Tag)
+	// ...but element metadata is NOT copied by index (no !lock leaks onto the wrong element).
+	require.Len(t, list.Content, 1)
+	require.NotEqual(t, "!lock", list.Content[0].Tag)
+	require.Equal(t, "ccc", list.Content[0].Value)
+}


### PR DESCRIPTION
As part of [PL-5900](https://nestoca.atlassian.net/browse/PL-5900), this adds `joy release preview create` and `joy release preview delete`, which respectively creates a preview copy of a given release, with given transforms, or deletes that copy. It is intended to be invoked from the `preview-service` workflow/action developed in [that PR](https://github.com/nestoca/actions/pull/1006).

[PL-5900]: https://nestoca.atlassian.net/browse/PL-5900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `joy preview` CLI command group to create and delete preview copies of releases, including versioning, RFC 6902 patch operations, text replacements, and placeholder substitution.
  * Preview copies are now marked with a dedicated preview label.
* **Bug Fixes**
  * Preview-labeled releases are automatically excluded during promotion.
  * Recreating an existing preview updates only its version.
* **Tests**
  * Added coverage for preview create/update/delete, patch parsing/application and validation, YAML metadata preservation, and promotion skipping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->