### PR TITLE
feat(PL-6288): add reconcile status to joy resources

### DIFF
--- a/api/v1alpha1/catalog.go
+++ b/api/v1alpha1/catalog.go
@@ -1,15 +1,19 @@
 package v1alpha1
 
 import (
-	"github.com/nestoca/joy/internal/helm"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/nestoca/joy/internal/helm"
 )
 
 type Catalog struct {
 	metav1.TypeMeta   `yaml:",inline"`
 	metav1.ObjectMeta `json:"metadata" yaml:"metadata"`
-	Spec              CatalogSpec `json:"spec" yaml:"spec"`
+	Spec              CatalogSpec    `json:"spec" yaml:"spec"`
+	Status            ResourceStatus `json:"status,omitzero" yaml:"status,omitempty"`
 }
+
+func (c *Catalog) GetStatus() *ResourceStatus { return &c.Status }
 
 type CatalogSpec struct {
 	RepoURL  string        `json:"repoUrl" yaml:"repoUrl"`

--- a/api/v1alpha1/environment.go
+++ b/api/v1alpha1/environment.go
@@ -75,12 +75,17 @@ type Environment struct {
 	// Spec is the spec of the environment.
 	Spec EnvironmentSpec `yaml:"spec,omitempty" json:"spec,omitzero"`
 
+	// Status is the reconcile status set by the joy-operator (never by the CLI).
+	Status ResourceStatus `yaml:"status,omitempty" json:"status,omitzero"`
+
 	// File represents the in-memory yaml file of the project.
 	File *yml.File `yaml:"-" json:"-"`
 
 	// Dir is the path to the environment directory.
 	Dir string `yaml:"-" json:"-"`
 }
+
+func (e *Environment) GetStatus() *ResourceStatus { return &e.Status }
 
 func (e Environment) Validate(validChartRefs []string) error {
 	var errs []error

--- a/api/v1alpha1/release.go
+++ b/api/v1alpha1/release.go
@@ -80,6 +80,9 @@ type Release struct {
 	// Spec is the spec of the release.
 	Spec ReleaseSpec `yaml:"spec,omitempty" json:"spec,omitzero"`
 
+	// Status is the reconcile status set by the joy-operator (never by the CLI).
+	Status ResourceStatus `yaml:"status,omitempty" json:"status,omitzero"`
+
 	// File represents the in-memory yaml file of the release.
 	File *yml.File `yaml:"-" json:"-"`
 
@@ -133,6 +136,8 @@ func LoadRelease(file *yml.File) (*Release, error) {
 func (release *Release) GetName() string {
 	return release.ReleaseMetadata.Name
 }
+
+func (release *Release) GetStatus() *ResourceStatus { return &release.Status }
 
 func stripCustomTags(node *yaml.Node) *yaml.Node {
 	if slices.Contains(yml.CustomTags, node.Tag) {

--- a/api/v1alpha1/scheme.go
+++ b/api/v1alpha1/scheme.go
@@ -28,3 +28,12 @@ var (
 	ReleaseGVK     = schema.GroupVersionKind{Group: Group, Version: Version, Kind: ReleaseKind}
 	CatalogGVK     = schema.GroupVersionKind{Group: Group, Version: Version, Kind: CatalogKind}
 )
+
+// GroupVersionResource identifiers, using the plural resource names defined by
+// the generated CRDs (see joy-operator/cmd/crd-gen).
+var (
+	EnvironmentGVR = GroupVersion.WithResource("environments")
+	ProjectGVR     = GroupVersion.WithResource("projects")
+	ReleaseGVR     = GroupVersion.WithResource("releases")
+	CatalogGVR     = GroupVersion.WithResource("catalogs")
+)

--- a/api/v1alpha1/status.go
+++ b/api/v1alpha1/status.go
@@ -1,0 +1,36 @@
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ConditionReady is the condition type used to surface the outcome of the
+// operator's reconciliation of a resource.
+const ConditionReady = "Ready"
+
+// ResourceStatus is the shared status shape for joy resources reconciled by the
+// joy-operator. It is populated by the operator (never by the joy CLI) and is
+// surfaced as an Argo CD health status via a Lua health check.
+//
+// The json/yaml tag split on the fields embedding this struct is deliberate:
+// encoding/json needs "omitzero" to drop a zero struct, whereas gopkg.in/yaml.v3
+// needs "omitempty" (it recurses into structs and does not understand omitzero).
+// Both drop an unset status so it never lands in the catalog git repo, while a
+// populated status still serializes to the Kubernetes API.
+type ResourceStatus struct {
+	// ObservedGeneration is the generation of the resource that was last
+	// reconciled by the operator.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty" yaml:"observedGeneration,omitempty"`
+
+	// Conditions holds the latest observations of the resource's reconcile state.
+	Conditions []metav1.Condition `json:"conditions,omitempty" yaml:"conditions,omitempty"`
+}
+
+// StatusObject is the constraint satisfied by pointers to joy resource types
+// that expose a ResourceStatus. It lets the operator drive status updates for
+// every resource kind through a single generic helper.
+type StatusObject[T any] interface {
+	*T
+	metav1.Object
+	GetStatus() *ResourceStatus
+}


### PR DESCRIPTION
### Related PRs — PL-6288

One of 3 coordinated PRs:

- `joy` (API/type layer) — nestoca/joy#294
- `joy-operator` (status subresource + reconciler wiring) — nestoca/joy-operator#34
- `infra` (`joy.nesto.ca/*` Argo CD health check) — nestoca/infra#4872

**Merge order:** merge `joy` → cut a joy release → re-pin `joy-operator` `go.mod` to the tag → merge `joy-operator`. `infra` can merge any time (no-ops until resources carry conditions).

---

## What

This PR adds the **API/type layer**.

- New `api/v1alpha1/status.go`:
  - `ResourceStatus` (`observedGeneration` + `[]metav1.Condition`) — the shared status shape.
  - `StatusObject[T]` constraint so the operator can drive status updates for all resource kinds through one generic helper.
- `Status` field + `GetStatus()` on **Catalog**, **Environment**, **Release**.
- `GroupVersionResource` identifiers (`catalogs`/`environments`/`releases`/`projects`) in `scheme.go`.

### Why the `json:"...,omitzero" yaml:"...,omitempty"` tag split

Matches the existing convention in this package (e.g. `Chart`, `Spec`, `metadata`). For a non-pointer struct field the two codecs differ:

- `encoding/json`: `omitempty` is a no-op on a zero struct; `omitzero` (Go 1.24+) drops it.
- `gopkg.in/yaml.v3`: `omitempty` drops a zero struct; `omitzero` is unsupported.

Both spellings omit an **unset** status, so no `status: {}` lands in the catalog git repo, while a populated status (written by the operator) still serializes to the Kubernetes API. The joy CLI never sets status.

### Testing

- `go build ./...`, `go vet ./api/...` clean.
- `go test ./api/... ./pkg/catalog/...` pass.
- Full `go test ./...` clean except `TestReleaseRender/diff*`, which fails identically on `master` (git worktree fixture requires refs not present locally) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added status tracking to Catalog, Environment, and Release resources.
  * Added readiness condition support and observed-generation tracking.
  * Added resource identifiers for Environment, Project, Release, and Catalog resources.
  * Added a shared interface for accessing resource status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->