### PR TITLE
fix(PLT-6549): skip hidden directories when loading the catalog

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -73,6 +73,18 @@ func Load(ctx context.Context, dir string, validChartRefs []string) (*Catalog, e
 	// Load all matching files
 	c := &Catalog{Dir: dir}
 	for _, fileAsset := range fileAssets {
+		// Skip files living inside a hidden directory (e.g. .git, .claude).
+		// Nested git worktrees and checkouts are commonly placed under such
+		// folders (for example .claude/worktrees/<name>) and each contains its
+		// own full copy of the catalog. Without this, every environment,
+		// release and project would be loaded once per checkout, duplicating
+		// the whole catalog N times.
+		if hidden, err := hasHiddenDirSegment(dir, fileAsset.Path); err != nil {
+			return nil, err
+		} else if hidden {
+			continue
+		}
+
 		if ignoreMatcher != nil && ignoreMatcher.Match(fileAsset.Path) {
 			continue
 		}
@@ -236,6 +248,28 @@ func (c *Catalog) ResolveRefs() error {
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// hasHiddenDirSegment reports whether path lies within a hidden directory
+// (a path segment beginning with a dot) relative to root. The root directory
+// itself is intentionally excluded from the check, so a hidden catalog root
+// such as ~/.joy is loaded normally while its hidden subdirectories
+// (.git, .claude/worktrees, ...) are skipped.
+func hasHiddenDirSegment(root, path string) (bool, error) {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false, fmt.Errorf("resolving %s relative to %s: %w", path, root, err)
+	}
+
+	// Only inspect the directory portion: a hidden file at the catalog root is
+	// not considered "inside a hidden directory".
+	for dir := filepath.Dir(rel); dir != "." && dir != string(filepath.Separator); dir = filepath.Dir(dir) {
+		if strings.HasPrefix(filepath.Base(dir), ".") {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 func isValid(file *yml.File) bool {

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -125,6 +125,70 @@ func TestFreeformEnvsAndReleasesLoadingWithJoyIgnore(t *testing.T) {
 	require.Equal(t, "1.1.1", rels[1].Releases[0].Spec.Version)
 }
 
+func TestCatalogLoadIgnoresHiddenDirectories(t *testing.T) {
+	// Nested git worktrees and checkouts (for example under .claude/worktrees),
+	// as well as the .git directory, contain their own full copy of the
+	// catalog. They must not be loaded, otherwise every environment and project
+	// is duplicated once per checkout. Regression test for PLT-6549, where
+	// `joy env list` showed every environment 4x because of nested worktrees.
+	catalogDir, err := filepath.Abs("testdata/hidden-dirs")
+	require.NoError(t, err)
+
+	cat, err := Load(context.Background(), catalogDir, nil)
+	require.NoError(t, err)
+
+	// The catalog defines each of these exactly once; the hidden copies under
+	// .claude/worktrees and .git must be ignored.
+	require.Equal(t, []string{"dev"}, cat.GetEnvironmentNames())
+
+	require.Len(t, cat.Projects, 1)
+	require.Equal(t, "project1", cat.Projects[0].Name)
+}
+
+func TestHasHiddenDirSegment(t *testing.T) {
+	root := filepath.Join(string(filepath.Separator), "Users", "someone", ".joy")
+
+	cases := []struct {
+		Name string
+		Path string
+		Want bool
+	}{
+		{
+			Name: "regular catalog file",
+			Path: filepath.Join(root, "environments", "dev", "env.yaml"),
+			Want: false,
+		},
+		{
+			Name: "hidden file at catalog root is loaded",
+			Path: filepath.Join(root, ".hidden-file.yaml"),
+			Want: false,
+		},
+		{
+			Name: "inside .git",
+			Path: filepath.Join(root, ".git", "index.yaml"),
+			Want: true,
+		},
+		{
+			Name: "nested git worktree under .claude",
+			Path: filepath.Join(root, ".claude", "worktrees", "wt1", "environments", "dev", "env.yaml"),
+			Want: true,
+		},
+		{
+			Name: "hidden directory nested deeper",
+			Path: filepath.Join(root, "environments", ".backup", "env.yaml"),
+			Want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			got, err := hasHiddenDirSegment(root, tc.Path)
+			require.NoError(t, err)
+			require.Equal(t, tc.Want, got)
+		})
+	}
+}
+
 func requireRelease(t *testing.T, crossRelease *cross.Release, name string, devVersion string, prodVersion string) {
 	require.Equal(t, name, crossRelease.Name)
 	devRelease := crossRelease.Releases[0]

--- a/pkg/catalog/testdata/hidden-dirs/.claude/worktrees/wt1/environments/dev/env.yaml
+++ b/pkg/catalog/testdata/hidden-dirs/.claude/worktrees/wt1/environments/dev/env.yaml
@@ -1,0 +1,6 @@
+apiVersion: joy.nesto.ca/v1alpha1
+kind: Environment
+metadata:
+  name: dev
+spec:
+  order: 1

--- a/pkg/catalog/testdata/hidden-dirs/.claude/worktrees/wt1/projects/project1.yaml
+++ b/pkg/catalog/testdata/hidden-dirs/.claude/worktrees/wt1/projects/project1.yaml
@@ -1,0 +1,4 @@
+apiVersion: joy.nesto.ca/v1alpha1
+kind: Project
+metadata:
+  name: project1

--- a/pkg/catalog/testdata/hidden-dirs/environments/dev/env.yaml
+++ b/pkg/catalog/testdata/hidden-dirs/environments/dev/env.yaml
@@ -1,0 +1,6 @@
+apiVersion: joy.nesto.ca/v1alpha1
+kind: Environment
+metadata:
+  name: dev
+spec:
+  order: 1

--- a/pkg/catalog/testdata/hidden-dirs/projects/project1.yaml
+++ b/pkg/catalog/testdata/hidden-dirs/projects/project1.yaml
@@ -1,0 +1,4 @@
+apiVersion: joy.nesto.ca/v1alpha1
+kind: Project
+metadata:
+  name: project1


### PR DESCRIPTION
## Problem

[PLT-6549](https://nestoca.atlassian.net/browse/PLT-6549): `joy env list` shows every environment **duplicated 4×** (joy v0.99.0).

## Root cause

`catalog.Load` globs `<catalogDir>/**/*.yaml` and recurses into **every** subdirectory. When the catalog checkout contains nested git worktrees or clones under a hidden directory — e.g. `.claude/worktrees/<name>`, which each hold a full copy of the catalog — every `Environment`, `Release` and `Project` gets loaded once per checkout.

The reporter had the main checkout plus **3** git worktrees under `~/.joy/.claude/worktrees/`, i.e. 4 copies of `environments/` → each env listed 4×. Removing the worktrees made the duplication disappear, confirming the cause. `.git/` is scanned for the same reason.

## Fix

Skip any globbed file that lives inside a **hidden directory** (a path segment beginning with a dot), computed **relative to the catalog root**. The root itself is excluded from the check, so a hidden catalog root such as `~/.joy` still loads normally, while `.git`, `.claude/worktrees`, etc. are ignored.

Small, targeted change in `pkg/catalog/catalog.go` — no behavior change for catalogs without hidden subdirectories.

## Tests

- **`TestCatalogLoadIgnoresHiddenDirectories`** — E2E regression test: a catalog with a nested worktree copy under `.claude/worktrees/wt1/`; asserts each env/project loads exactly once. Verified it **fails without the fix** (env `dev` appears 2×) and passes with it.
- **`TestHasHiddenDirSegment`** — unit test for the helper, covering `.git`, nested worktrees under `.claude`, deeper hidden dirs, a regular file, and the hidden-catalog-root edge case (`~/.joy`).

`go build ./...`, `go vet ./pkg/catalog/`, `gofmt`, and `go test ./pkg/catalog/` all pass.

## Notes

- Worktrees placed in a **non-hidden** directory would still duplicate; `.joyignore` remains the escape hatch for that. This change covers the common/reported layout where tooling puts worktrees under a dot-folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PLT-6549]: https://nestoca.atlassian.net/browse/PLT-6549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped filter before existing `.joyignore` and YAML parsing; catalogs without hidden nested copies behave the same, with the edge case that intentional CRDs under dot-folders (e.g. `.backup`) would no longer load unless moved or ignored differently.
> 
> **Overview**
> Fixes **duplicate environments/releases/projects** when the catalog tree includes nested checkouts under dot-directories (e.g. `.git`, `.claude/worktrees/<name>`), which caused commands like `joy env list` to show each entry multiple times.
> 
> **`catalog.Load`** now skips globbed `**/*.yaml` files whose path (relative to the catalog root) passes through a **hidden directory segment** (any parent folder whose name starts with `.`). The catalog root itself is not treated as hidden, so roots like `~/.joy` still load normally; only hidden *subdirectories* are excluded. `.joyignore` behavior is unchanged.
> 
> Adds **`hasHiddenDirSegment`** and regression coverage: integration test with a duplicate catalog under `.claude/worktrees`, plus unit cases for `.git`, nested hidden dirs, and dot-files at the catalog root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45f6ef95cba5e9b8327623018aa3f40947366935. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Catalog loading now ignores resources inside hidden directories, preventing duplicate environments and projects from being discovered.
  * Hidden catalog roots and root-level hidden files continue to load correctly.
  * Path resolution failures are now reported as errors.

* **Tests**
  * Added coverage for hidden directories, nested worktrees, and copied repository metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->