### PR TITLE
fix: warn when updating an existing preview skips patches/replacements

### DIFF
--- a/internal/preview/preview.go
+++ b/internal/preview/preview.go
@@ -68,6 +68,12 @@ func Create(params CreateParams) error {
 	targetPath := filepath.Join(filepath.Dir(source.File.Path), target+".yaml")
 
 	if _, err := os.Stat(targetPath); err == nil {
+		if len(params.Patches) > 0 || len(params.Replaces) > 0 {
+			fmt.Printf(
+				"%s existing preview %s: only spec.version is updated, patches and replacements are not re-applied. Delete and recreate the preview to pick up changes to those.\n",
+				style.Warning("⚠️"), style.Resource(target),
+			)
+		}
 		return updateVersion(params.Writer, targetPath, params.Version, target)
 	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("checking preview file %s: %w", targetPath, err)

--- a/internal/preview/preview_test.go
+++ b/internal/preview/preview_test.go
@@ -1,6 +1,7 @@
 package preview
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -138,6 +139,48 @@ func TestCreateUpdateOnlyBumpsVersion(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(text), "version: 9.9.9")
 	require.NotContains(t, string(text), "SHOULD_NOT_APPEAR")
+}
+
+func TestCreateUpdateWarnsAboutSkippedPatches(t *testing.T) {
+	_, cat := newCatalog(t)
+	require.NoError(t, Create(CreateParams{
+		Catalog: cat, Writer: yml.DiskWriter, Env: "staging",
+		Release: "backoffice", Suffix: "-og-1234", Version: "1.0.0", Patches: nestoPatches(t),
+	}))
+
+	captureStdout := func(fn func()) string {
+		old := os.Stdout
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		os.Stdout = w
+		defer func() { os.Stdout = old }()
+
+		fn()
+
+		require.NoError(t, w.Close())
+		out, err := io.ReadAll(r)
+		require.NoError(t, err)
+		return string(out)
+	}
+
+	// Update without patches/replaces: no warning.
+	out := captureStdout(func() {
+		require.NoError(t, Create(CreateParams{
+			Catalog: cat, Writer: yml.DiskWriter, Env: "staging",
+			Release: "backoffice", Suffix: "-og-1234", Version: "2.0.0",
+		}))
+	})
+	require.NotContains(t, out, "not re-applied")
+
+	// Update with patches: warns that they're skipped.
+	out = captureStdout(func() {
+		require.NoError(t, Create(CreateParams{
+			Catalog: cat, Writer: yml.DiskWriter, Env: "staging",
+			Release: "backoffice", Suffix: "-og-1234", Version: "3.0.0", Patches: nestoPatches(t),
+		}))
+	})
+	require.Contains(t, out, "backoffice-og-1234")
+	require.Contains(t, out, "not re-applied")
 }
 
 func TestDelete(t *testing.T) {


### PR DESCRIPTION
Create() on an existing preview only bumps spec.version, patches/replaces never get re-applied — intentional (#293), but silent. Spent a chunk of this afternoon debugging why an annotation fix on backoffice#4396 "wasn't taking": the preview file already existed, so every push just re-stamped the version and kept redeploying the old broken annotation underneath. Added a print so the next person doesn't lose the same hour. Delete+recreate is still the only way to actually apply new patches, this just says so out loud instead of staying quiet about it.

go test ./internal/preview/... — added a case for both the warn and no-warn paths.