### PR TITLE
feat: merge patch for preview transforms

### DIFF
--- a/cmd/joy/release_preview.go
+++ b/cmd/joy/release_preview.go
@@ -20,7 +20,8 @@ func NewReleasePreviewCmd() *cobra.Command {
 
 A preview is a copy of a source release named <release><suffix>, pinned to a version and
 labelled ` + "`joy.nesto.ca/preview`" + ` so that "joy build promote" excludes it. Callers layer
-their own transforms via repeatable --patch (RFC 6902 op) and --replace (regex) flags.`,
+their own transforms via repeatable --patch (RFC 6902 op) flags, a single --merge-patch
+(RFC 7386) flag, and repeatable --replace (regex) flags.`,
 	}
 	cmd.AddCommand(newReleasePreviewCreateCmd())
 	cmd.AddCommand(newReleasePreviewDeleteCmd())
@@ -29,11 +30,12 @@ their own transforms via repeatable --patch (RFC 6902 op) and --replace (regex) 
 
 func newReleasePreviewCreateCmd() *cobra.Command {
 	var (
-		env      string
-		suffix   string
-		version  string
-		patches  []string
-		replaces []string
+		env        string
+		suffix     string
+		version    string
+		patches    []string
+		mergePatch string
+		replaces   []string
 	)
 
 	cmd := &cobra.Command{
@@ -42,8 +44,8 @@ func newReleasePreviewCreateCmd() *cobra.Command {
 		Long: `Create a preview copy of <release> named <release><suffix> in the given environment.
 
 Applies, in order: built-ins (metadata.name, joy.nesto.ca/preview label, spec.version), then
-each --patch, then each --replace, then a final placeholder pass (__RELEASE__, __SUFFIX__).
-If the preview already exists, only spec.version is updated.`,
+each --patch, then --merge-patch, then each --replace, then a final placeholder pass
+(__RELEASE__, __SUFFIX__). If the preview already exists, only spec.version is updated.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ops, err := parsePatchFlags(patches)
@@ -59,14 +61,15 @@ If the preview already exists, only spec.version is updated.`,
 			cat.WithEnvironments([]string{env})
 
 			return preview.Create(preview.CreateParams{
-				Catalog:  cat,
-				Writer:   yml.DiskWriter,
-				Env:      env,
-				Release:  args[0],
-				Suffix:   suffix,
-				Version:  version,
-				Patches:  ops,
-				Replaces: replacements,
+				Catalog:    cat,
+				Writer:     yml.DiskWriter,
+				Env:        env,
+				Release:    args[0],
+				Suffix:     suffix,
+				Version:    version,
+				Patches:    ops,
+				MergePatch: []byte(mergePatch),
+				Replaces:   replacements,
 			})
 		},
 	}
@@ -75,6 +78,7 @@ If the preview already exists, only spec.version is updated.`,
 	cmd.Flags().StringVar(&suffix, "suffix", "", "Suffix appended to the release name to form the preview (include the leading dash, e.g. -og-1234)")
 	cmd.Flags().StringVar(&version, "version", "", "Version to set on the preview release")
 	cmd.Flags().StringArrayVar(&patches, "patch", nil, "(repeatable) A single RFC 6902 op (add/replace/remove) applied to the preview, as JSON/YAML")
+	cmd.Flags().StringVar(&mergePatch, "merge-patch", "", "An RFC 7386 JSON Merge Patch applied to the preview, as JSON/YAML")
 	cmd.Flags().StringArrayVar(&replaces, "replace", nil, "(repeatable) A single {search, replace} regex applied to the preview file text, as JSON/YAML")
 	_ = cmd.MarkFlagRequired("env")
 	_ = cmd.MarkFlagRequired("suffix")

--- a/internal/patch/patch.go
+++ b/internal/patch/patch.go
@@ -1,4 +1,5 @@
-// Package patch applies RFC 6902 JSON Patch operations to a YAML release tree.
+// Package patch applies RFC 6902 JSON Patch ops or an RFC 7386 JSON Merge Patch to a YAML
+// release tree.
 //
 // The patch itself is applied by a standard JSON Patch library, so serialization to JSON is
 // required — which drops YAML custom tags (e.g. !lock), comments and key order. Those are
@@ -67,12 +68,46 @@ func Apply(doc *yaml.Node, ops []Op) (*yaml.Node, error) {
 		return nil, fmt.Errorf("applying patch: %w", err)
 	}
 
+	return finish(doc, patchedJSON)
+}
+
+// ApplyMergePatch applies an RFC 7386 JSON Merge Patch (given as YAML or JSON) to doc and returns
+// the resulting document. Unlike Apply's path-addressed ops, a merge patch is just the target
+// shape: setting a key merges it in (whether it existed before or not), setting it to null
+// removes it. Metadata/style are restored the same way as Apply. When mergePatch is empty, doc is
+// returned unchanged.
+func ApplyMergePatch(doc *yaml.Node, mergePatch []byte) (*yaml.Node, error) {
+	if len(mergePatch) == 0 {
+		return doc, nil
+	}
+
+	docJSON, err := toJSON(doc)
+	if err != nil {
+		return nil, fmt.Errorf("converting release to json: %w", err)
+	}
+
+	patchJSON, err := sigsyaml.YAMLToJSON(mergePatch)
+	if err != nil {
+		return nil, fmt.Errorf("converting merge patch to json: %w", err)
+	}
+
+	patchedJSON, err := jsonpatch.MergePatch(docJSON, patchJSON)
+	if err != nil {
+		return nil, fmt.Errorf("applying merge patch: %w", err)
+	}
+
+	return finish(doc, patchedJSON)
+}
+
+// finish unmarshals patchedJSON back into a yaml.Node, restoring the custom tags, comments and
+// key order that the JSON round-trip drops (from the pre-patch doc), and clears flow-flattened
+// styles so the result serializes as clean block YAML.
+func finish(doc *yaml.Node, patchedJSON []byte) (*yaml.Node, error) {
 	var patched yaml.Node
 	if err := yaml.Unmarshal(patchedJSON, &patched); err != nil {
 		return nil, fmt.Errorf("parsing patched result: %w", err)
 	}
 
-	// The JSON round-trip drops custom tags, comments and key order, and flow-flattens styles.
 	yml.CopyMetadata(&patched, doc)
 	clearStyle(&patched)
 	return &patched, nil

--- a/internal/patch/patch_test.go
+++ b/internal/patch/patch_test.go
@@ -81,6 +81,37 @@ func TestApply_StrictErrors(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestApplyMergePatch(t *testing.T) {
+	out, err := ApplyMergePatch(doc(t, base), []byte(`
+spec:
+  values:
+    image: {name: backoffice}
+    env: {ALPHA: A2}
+    frontend: {gateway: null}
+`))
+	require.NoError(t, err)
+	s := render(t, out)
+
+	// Custom tags restored by CopyMetadata (including on a replaced value).
+	require.Contains(t, s, "ZULU: !lock z")
+	require.Contains(t, s, "ALPHA: !lock A2")
+	// Source key order preserved (ZULU before ALPHA), not alphabetized.
+	require.Less(t, strings.Index(s, "ZULU"), strings.Index(s, "ALPHA"))
+	// De-flowed to block style (no leftover JSON braces from the round-trip).
+	require.NotContains(t, s, `{"`)
+	// Merge effects: object merged in, null removes the key.
+	require.Contains(t, s, "name: backoffice")
+	require.NotContains(t, s, "httpRoutes")
+	require.Contains(t, s, "namespace: default")
+}
+
+func TestApplyMergePatch_EmptyReturnsInput(t *testing.T) {
+	in := doc(t, base)
+	out, err := ApplyMergePatch(in, nil)
+	require.NoError(t, err)
+	require.Same(t, in, out)
+}
+
 func TestSetPathAndSetPathCreating(t *testing.T) {
 	d := doc(t, base)
 	root := d.Content[0]

--- a/internal/preview/preview.go
+++ b/internal/preview/preview.go
@@ -2,7 +2,8 @@
 //
 // A preview is a copy of a source release named <sourceRelease><suffix>, pinned to a specific
 // build version and marked with the v1alpha1.PreviewLabel so that `joy build promote` excludes
-// it. Callers layer their own transforms via patches (RFC 6902) and regex replacements.
+// it. Callers layer their own transforms via patches (RFC 6902), a merge patch (RFC 7386) and
+// regex replacements.
 package preview
 
 import (
@@ -29,14 +30,15 @@ type Replacement struct {
 
 // CreateParams are the inputs to Create.
 type CreateParams struct {
-	Catalog  *catalog.Catalog
-	Writer   yml.Writer
-	Env      string
-	Release  string // source release name
-	Suffix   string // appended to Release to form the preview name; includes any leading dash
-	Version  string
-	Patches  []patch.Op
-	Replaces []Replacement
+	Catalog    *catalog.Catalog
+	Writer     yml.Writer
+	Env        string
+	Release    string // source release name
+	Suffix     string // appended to Release to form the preview name; includes any leading dash
+	Version    string
+	Patches    []patch.Op
+	MergePatch []byte // RFC 7386 JSON Merge Patch (YAML or JSON), applied after Patches
+	Replaces   []Replacement
 }
 
 // DeleteParams are the inputs to Delete.
@@ -50,8 +52,9 @@ type DeleteParams struct {
 // Create writes (or, if it already exists, version-bumps) the preview copy of a release.
 //
 // New preview: copy source → built-ins (metadata.name, preview label, version) → patches →
-// replacements → placeholder substitution (__RELEASE__, __SUFFIX__). Existing preview: only
-// spec.version is re-patched (copy is idempotent; other transforms are not re-applied).
+// merge patch → replacements → placeholder substitution (__RELEASE__, __SUFFIX__). Existing
+// preview: only spec.version is re-patched (copy is idempotent; other transforms are not
+// re-applied).
 func Create(params CreateParams) error {
 	source, err := findSourceRelease(params.Catalog, params.Release, params.Env)
 	if err != nil {
@@ -68,7 +71,7 @@ func Create(params CreateParams) error {
 	targetPath := filepath.Join(filepath.Dir(source.File.Path), target+".yaml")
 
 	if _, err := os.Stat(targetPath); err == nil {
-		if len(params.Patches) > 0 || len(params.Replaces) > 0 {
+		if len(params.Patches) > 0 || len(params.MergePatch) > 0 || len(params.Replaces) > 0 {
 			fmt.Printf(
 				"%s existing preview %s: only spec.version is updated, patches and replacements are not re-applied. Delete and recreate the preview to pick up changes to those.\n",
 				style.Warning("⚠️"), style.Resource(target),
@@ -95,6 +98,12 @@ func Create(params CreateParams) error {
 
 	// Caller patches (RFC 6902), applied via the JSON Patch library (tags/comments/order restored).
 	patched, err := patch.Apply(tree, params.Patches)
+	if err != nil {
+		return err
+	}
+
+	// Caller merge patch (RFC 7386), applied on top of the RFC 6902 patches.
+	patched, err = patch.ApplyMergePatch(patched, params.MergePatch)
 	if err != nil {
 		return err
 	}

--- a/internal/preview/preview_test.go
+++ b/internal/preview/preview_test.go
@@ -120,6 +120,42 @@ func TestCreate(t *testing.T) {
 	require.Equal(t, "backoffice", spec["values"].(map[string]any)["image"].(map[string]any)["name"])
 }
 
+func TestCreateWithMergePatch(t *testing.T) {
+	dir, cat := newCatalog(t)
+	err := Create(CreateParams{
+		Catalog: cat, Writer: yml.DiskWriter,
+		Env: "staging", Release: "backoffice", Suffix: "-og-1234", Version: "1.2.3-preview",
+		MergePatch: []byte(`
+metadata:
+  annotations:
+    argocd.nesto.ca/sync.prune: 'true'
+spec:
+  values:
+    frontend:
+      gateway: null
+`),
+		Replaces: []Replacement{{
+			Search:  `(https://)(office)(\.staging\..*/api)`,
+			Replace: `${1}__RELEASE____SUFFIX__.previews$3`,
+		}},
+	})
+	require.NoError(t, err)
+
+	text, err := os.ReadFile(previewPath(dir))
+	require.NoError(t, err)
+	s := string(text)
+
+	require.Contains(t, s, "name: backoffice-og-1234")
+	require.Contains(t, s, "version: 1.2.3-preview")
+	require.NotContains(t, s, "gateway")
+	require.Contains(t, s, "PUBLIC_API_PATH: !lock https://backoffice-og-1234.previews.staging.nesto.ca/api")
+
+	// The slash in the annotation key needs no escaping with a merge patch.
+	m := decode(t, previewPath(dir))
+	annotations := m["metadata"].(map[string]any)["annotations"].(map[string]any)
+	require.Equal(t, "true", annotations["argocd.nesto.ca/sync.prune"])
+}
+
 func TestCreateUpdateOnlyBumpsVersion(t *testing.T) {
 	dir, cat := newCatalog(t)
 	require.NoError(t, Create(CreateParams{
@@ -180,6 +216,16 @@ func TestCreateUpdateWarnsAboutSkippedPatches(t *testing.T) {
 		}))
 	})
 	require.Contains(t, out, "backoffice-og-1234")
+	require.Contains(t, out, "not re-applied")
+
+	// Update with a merge patch (no --patch ops): also warns.
+	out = captureStdout(func() {
+		require.NoError(t, Create(CreateParams{
+			Catalog: cat, Writer: yml.DiskWriter, Env: "staging",
+			Release: "backoffice", Suffix: "-og-1234", Version: "4.0.0",
+			MergePatch: []byte(`{spec: {values: {image: {name: backoffice}}}}`),
+		}))
+	})
 	require.Contains(t, out, "not re-applied")
 }
 


### PR DESCRIPTION
Stacked on #297 (same CreateParams area).

Adding preview releases sometimes need to set a key with a slash in it (e.g. `argocd.nesto.ca/sync.prune`). RFC 6902 JSON Patch addresses keys by JSON Pointer path, so a literal `/` needs `~1` escaping. That escaping got mangled on backoffice#4396 and produced an invalid k8s annotation name apiserver silently rejected.

Preview create now takes a `--merge-patch` flag (RFC 7386) alongside the existing `--patch`/`--replace`. A merge patch is just the target shape in plain YAML, no path syntax, so a slash in a key is a normal map key, no escaping needed. Runs after patches, before replacements. Existing flags unchanged.

go test ./internal/patch/... ./internal/preview/... passes.