### PR TITLE
fix(PL-5900): regen previews from scratch every time

### DIFF
--- a/internal/preview/preview.go
+++ b/internal/preview/preview.go
@@ -67,12 +67,6 @@ func Create(params CreateParams) error {
 	target := params.Release + params.Suffix
 	targetPath := filepath.Join(filepath.Dir(source.File.Path), target+".yaml")
 
-	if _, err := os.Stat(targetPath); err == nil {
-		return updateVersion(params.Writer, targetPath, params.Version, target)
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("checking preview file %s: %w", targetPath, err)
-	}
-
 	tree := yml.Clone(source.File.Tree)
 	node := documentRoot(tree)
 
@@ -137,24 +131,6 @@ func Delete(params DeleteParams) error {
 		return fmt.Errorf("removing preview file %s: %w", targetPath, err)
 	}
 	fmt.Printf("🗑️  Deleted preview %s\n", style.Resource(target))
-	return nil
-}
-
-func updateVersion(writer yml.Writer, path, version, target string) error {
-	file, err := yml.LoadFile(path)
-	if err != nil {
-		return fmt.Errorf("loading preview file %s: %w", path, err)
-	}
-	if err := patch.SetPath(documentRoot(file.Tree), []string{"spec", "version"}, patch.Scalar(version)); err != nil {
-		return fmt.Errorf("setting spec.version: %w", err)
-	}
-	if err := file.UpdateYamlFromTree(); err != nil {
-		return fmt.Errorf("updating preview yaml: %w", err)
-	}
-	if err := writer.WriteFile(file); err != nil {
-		return fmt.Errorf("writing preview file: %w", err)
-	}
-	fmt.Printf("✅ Updated preview %s to version %s\n", style.Resource(target), style.Version(version))
 	return nil
 }
 

--- a/internal/preview/preview_test.go
+++ b/internal/preview/preview_test.go
@@ -119,27 +119,6 @@ func TestCreate(t *testing.T) {
 	require.Equal(t, "backoffice", spec["values"].(map[string]any)["image"].(map[string]any)["name"])
 }
 
-func TestCreateUpdateOnlyBumpsVersion(t *testing.T) {
-	dir, cat := newCatalog(t)
-	require.NoError(t, Create(CreateParams{
-		Catalog: cat, Writer: yml.DiskWriter, Env: "staging",
-		Release: "backoffice", Suffix: "-og-1234", Version: "1.0.0", Patches: nestoPatches(t),
-	}))
-
-	// Second create with a different version + a patch that must NOT be re-applied.
-	extra, err := patch.ParseOp([]byte(`{op: add, path: /spec/values/SHOULD_NOT_APPEAR, value: x}`))
-	require.NoError(t, err)
-	require.NoError(t, Create(CreateParams{
-		Catalog: cat, Writer: yml.DiskWriter, Env: "staging",
-		Release: "backoffice", Suffix: "-og-1234", Version: "9.9.9", Patches: []patch.Op{extra},
-	}))
-
-	text, err := os.ReadFile(previewPath(dir))
-	require.NoError(t, err)
-	require.Contains(t, string(text), "version: 9.9.9")
-	require.NotContains(t, string(text), "SHOULD_NOT_APPEAR")
-}
-
 func TestDelete(t *testing.T) {
 	dir, cat := newCatalog(t)
 	require.NoError(t, Create(CreateParams{


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes update semantics for existing preview YAML files: previously only `spec.version` was bumped, now the full copy/patch flow overwrites the file. Callers that relied on preserving prior preview content may see different results.
> 
> **Overview**
> **`Create` always regenerates previews from the source release**, instead of short-circuiting to a version-only update when the target file already exists.
> 
> Removes the `updateVersion` helper and the test that asserted patches were *not* re-applied on update. Re-running create now re-applies built-ins, patches, and replacements so existing previews pick up the latest transforms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f814022f572d18c1c6e47f6a08d3783b20aab3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preview creation now consistently applies the full preview-copy flow, ensuring updates include the latest changes rather than only incrementing the version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->