### PR TITLE
fix(PLT-5890): previews should be created with argocd prune annotation

### DIFF
--- a/api/v1alpha1/scheme.go
+++ b/api/v1alpha1/scheme.go
@@ -15,7 +15,10 @@ const (
 
 // PreviewLabel marks a release as a preview copy created by `joy release preview`.
 // `joy build promote` always excludes releases carrying this label.
-const PreviewLabel = "joy.nesto.ca/preview"
+const (
+	PreviewLabel        = "joy.nesto.ca/preview"
+	PruneArgoAnnotation = "argocd.nesto.ca/sync.prune"
+)
 
 var GroupVersion = schema.GroupVersion{Group: Group, Version: Version}
 

--- a/internal/preview/preview.go
+++ b/internal/preview/preview.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/nestoca/joy/api/v1alpha1"
 	"github.com/nestoca/joy/internal/patch"
@@ -69,7 +68,8 @@ func Create(params CreateParams) error {
 	text, err := func() ([]byte, error) {
 		tree := yml.Clone(source.File.Tree)
 		yml.SetOrAddNodeValue(tree, "metadata.name", target)
-		yml.SetOrAddNodeValue(tree, "metadata.labels."+strings.ReplaceAll(v1alpha1.PreviewLabel, ".", "\\."), "true")
+		yml.SetOrAddNodeValue(tree, "metadata.labels."+yml.EscapePathSegment(v1alpha1.PreviewLabel), "true")
+		yml.SetOrAddNodeValue(tree, "metadata.annotations."+yml.EscapePathSegment(v1alpha1.PruneArgoAnnotation), "true")
 		yml.SetOrAddNodeValue(tree, "spec.version", params.Version)
 
 		if len(params.Patches) == 0 {

--- a/internal/preview/preview_test.go
+++ b/internal/preview/preview_test.go
@@ -105,6 +105,7 @@ func TestCreate(t *testing.T) {
 
 	m := decode(t, previewPath(dir))
 	require.Equal(t, "true", m["metadata"].(map[string]any)["labels"].(map[string]any)[v1alpha1.PreviewLabel])
+	require.Equal(t, "true", m["metadata"].(map[string]any)["annotations"].(map[string]any)[v1alpha1.PruneArgoAnnotation])
 	spec := m["spec"].(map[string]any)
 	require.Equal(t, "previews", spec["namespace"])
 	require.Equal(t, "backoffice", spec["values"].(map[string]any)["image"].(map[string]any)["name"])

--- a/internal/yml/find_node.go
+++ b/internal/yml/find_node.go
@@ -166,3 +166,7 @@ func SplitIntoPathSegments(input string) (result []string) {
 
 	return
 }
+
+func EscapePathSegment(text string) string {
+	return strings.ReplaceAll(text, `.`, `\.`)
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to preview creation metadata with test coverage; no auth or core promotion logic changes.
> 
> **Overview**
> Preview release copies now get **`argocd.nesto.ca/sync.prune: "true"`** on `metadata.annotations` when `joy release preview` creates them, so ArgoCD can prune cluster resources when a preview is removed from the catalog.
> 
> The annotation key is defined as **`PruneArgoAnnotation`** alongside the existing preview label in `api/v1alpha1`. Label and annotation YAML paths use a shared **`yml.EscapePathSegment`** helper instead of inline dot-escaping for dotted keys like `joy.nesto.ca/preview`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b5f048034c38f901648a8f1add3c82365314d2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preview resources are now marked for automatic pruning by Argo CD.

* **Bug Fixes**
  * Improved handling of annotation and label paths containing dots, ensuring preview configuration is applied correctly.

* **Tests**
  * Added coverage verifying that generated preview resources include the required pruning annotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->